### PR TITLE
Commented out help lines breaking parsing

### DIFF
--- a/src/Aggregator/CronJob/BrokenCronJobCountAggregator.php
+++ b/src/Aggregator/CronJob/BrokenCronJobCountAggregator.php
@@ -33,8 +33,8 @@ class BrokenCronJobCountAggregator implements MetricAggregatorInterface
     public function getHelp(): string
     {
         return <<<'TAG'
-Magento 2 CronJob Broken Count. 
-Broken CronJobs occur when when status is pending but execution_time is set.
+# Magento 2 CronJob Broken Count. 
+# Broken CronJobs occur when when status is pending but execution_time is set.
 TAG;
     }
 


### PR DESCRIPTION
I had to do this because exporter output was unparsable with the uncommented lines with Prometheus trying to parse "CronJob" as a float and failing