### PR TITLE
Reset order count and order amount metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2021-06-11
+
+### Fixed
+
+- Reset order count/amount metric before setting them
+
 ## [2.0.1] - 2021-05-31
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "run_as_root/magento2-prometheus-exporter",
     "description": "Magento2 Prometheus Exporter",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "type": "magento2-module",
     "license": "MIT",
     "homepage": "https://github.com/run-as-root/magento2-prometheus-exporter",

--- a/src/Aggregator/Order/OrderAmountAggregator.php
+++ b/src/Aggregator/Order/OrderAmountAggregator.php
@@ -30,8 +30,7 @@ class OrderAmountAggregator implements MetricAggregatorInterface
         SearchCriteriaBuilder $searchCriteriaBuilder,
         StoreRepositoryInterface $storeRepository,
         UpdateMetricServiceInterface $updateMetricService
-    )
-    {
+    ) {
         $this->metricRepository = $metricRepository;
         $this->orderRepository = $orderRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;

--- a/src/Aggregator/Order/OrderAmountAggregator.php
+++ b/src/Aggregator/Order/OrderAmountAggregator.php
@@ -8,8 +8,9 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
+use RunAsRoot\PrometheusExporter\Api\Data\MetricInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
-use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
 use function array_key_exists;
 
@@ -17,21 +18,25 @@ class OrderAmountAggregator implements MetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_amount_total';
 
-    private $updateMetricService;
-    private $orderRepository;
-    private $searchCriteriaBuilder;
-    private $storeRepository;
+    private MetricRepository $metricRepository;
+    private OrderRepositoryInterface $orderRepository;
+    private SearchCriteriaBuilder $searchCriteriaBuilder;
+    private StoreRepositoryInterface $storeRepository;
+    private UpdateMetricServiceInterface $updateMetricService;
 
     public function __construct(
-        UpdateMetricServiceInterface $updateMetricService,
+        MetricRepository $metricRepository,
         OrderRepositoryInterface $orderRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
         StoreRepositoryInterface $storeRepository,
-        SearchCriteriaBuilder $searchCriteriaBuilder
-    ) {
-        $this->updateMetricService = $updateMetricService;
+        UpdateMetricServiceInterface $updateMetricService
+    )
+    {
+        $this->metricRepository = $metricRepository;
         $this->orderRepository = $orderRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->storeRepository = $storeRepository;
+        $this->updateMetricService = $updateMetricService;
     }
 
     public function getCode(): string
@@ -51,8 +56,9 @@ class OrderAmountAggregator implements MetricAggregatorInterface
 
     public function aggregate(): bool
     {
-        $searchCriteria = $this->searchCriteriaBuilder->create();
+        $this->resetMetrics();
 
+        $searchCriteria = $this->searchCriteriaBuilder->create();
         $orderSearchResult = $this->orderRepository->getList($searchCriteria);
 
         if ($orderSearchResult->getTotalCount() === 0) {
@@ -86,12 +92,24 @@ class OrderAmountAggregator implements MetricAggregatorInterface
 
         foreach ($grandTotalsByStore as $storeCode => $grandTotals) {
             foreach ($grandTotals as $state => $grandTotal) {
-                $labels = [ 'state' => $state, 'store_code' => $storeCode ];
+                $labels = ['state' => $state, 'store_code' => $storeCode];
 
                 $this->updateMetricService->update(self::METRIC_CODE, (string)$grandTotal, $labels);
             }
         }
 
         return true;
+    }
+
+    protected function resetMetrics(): void
+    {
+        $searchCriteriaMetrics = $this->searchCriteriaBuilder->addFilter('code', self::METRIC_CODE)->create();
+        $metricsSearchResult = $this->metricRepository->getList($searchCriteriaMetrics);
+        $metrics = $metricsSearchResult->getItems();
+        /** @var MetricInterface $metric */
+        foreach ($metrics as $metric) {
+            $metric->setValue("0");
+            $this->metricRepository->save($metric);
+        }
     }
 }

--- a/src/Aggregator/Order/OrderCountAggregator.php
+++ b/src/Aggregator/Order/OrderCountAggregator.php
@@ -30,8 +30,7 @@ class OrderCountAggregator implements MetricAggregatorInterface
         SearchCriteriaBuilder $searchCriteriaBuilder,
         StoreRepositoryInterface $storeRepository,
         UpdateMetricService $updateMetricService
-    )
-    {
+    ) {
         $this->metricRepository = $metricRepository;
         $this->orderRepository = $orderRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;

--- a/src/Aggregator/Order/OrderCountAggregator.php
+++ b/src/Aggregator/Order/OrderCountAggregator.php
@@ -8,7 +8,9 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
+use RunAsRoot\PrometheusExporter\Api\Data\MetricInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 use function array_key_exists;
 
@@ -16,21 +18,25 @@ class OrderCountAggregator implements MetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_count_total';
 
-    private $updateMetricService;
-    private $orderRepository;
-    private $searchCriteriaBuilder;
-    private $storeRepository;
+    private MetricRepository $metricRepository;
+    private OrderRepositoryInterface $orderRepository;
+    private SearchCriteriaBuilder $searchCriteriaBuilder;
+    private StoreRepositoryInterface $storeRepository;
+    private UpdateMetricService $updateMetricService;
 
     public function __construct(
-        UpdateMetricService $updateMetricService,
+        MetricRepository $metricRepository,
         OrderRepositoryInterface $orderRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
         StoreRepositoryInterface $storeRepository,
-        SearchCriteriaBuilder $searchCriteriaBuilder
-    ) {
-        $this->updateMetricService = $updateMetricService;
+        UpdateMetricService $updateMetricService
+    )
+    {
+        $this->metricRepository = $metricRepository;
         $this->orderRepository = $orderRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->storeRepository = $storeRepository;
+        $this->updateMetricService = $updateMetricService;
     }
 
     public function getCode(): string
@@ -50,8 +56,9 @@ class OrderCountAggregator implements MetricAggregatorInterface
 
     public function aggregate(): bool
     {
-        $searchCriteria = $this->searchCriteriaBuilder->create();
+        $this->resetMetrics();
 
+        $searchCriteria = $this->searchCriteriaBuilder->create();
         $orderSearchResult = $this->orderRepository->getList($searchCriteria);
 
         if ($orderSearchResult->getTotalCount() === 0) {
@@ -85,12 +92,24 @@ class OrderCountAggregator implements MetricAggregatorInterface
 
         foreach ($countByStore as $storeCode => $countByState) {
             foreach ($countByState as $state => $count) {
-                $labels = [ 'state' => $state, 'store_code' => $storeCode ];
+                $labels = ['state' => $state, 'store_code' => $storeCode];
 
                 $this->updateMetricService->update(self::METRIC_CODE, (string)$count, $labels);
             }
         }
 
         return true;
+    }
+
+    protected function resetMetrics(): void
+    {
+        $searchCriteriaMetrics = $this->searchCriteriaBuilder->addFilter('code', self::METRIC_CODE)->create();
+        $metricsSearchResult = $this->metricRepository->getList($searchCriteriaMetrics);
+        $metrics = $metricsSearchResult->getItems();
+        /** @var MetricInterface $metric */
+        foreach ($metrics as $metric) {
+            $metric->setValue("0");
+            $this->metricRepository->save($metric);
+        }
     }
 }


### PR DESCRIPTION
If you have one order which is in state processing and the state changes
after the metric aggregation to complete, than the metrics still count
one order as processing and +1 for complete. You have to reset the
metric values before the aggregation, otherwise you get incorrect data.

Please create a new git tag after merging this PR 😉