### PR TITLE
Issue 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,21 @@ in the table and renders the correct response for prometheus.
 
 The following metrics will be collected:
 
-| Metric                              | Labels                 | TYPE  | Help                                                                         |
-|:------------------------------------|:-----------------------|:------|:-----------------------------------------------------------------------------|
-| magento_orders_count_total          | status, store_code     | gauge | All Magento Orders                                                           |
-| magento_orders_amount_total         | status, store_code     | gauge | Total amount of all Magento Orders                                           |
-| magento_order_items_count_total     | status, store_code     | gauge | Total count of orderitems                                                    |
-| magento_cms_block_count_total       | store_code             | gauge | Total count of available cms blocks                                          |
-| magento_cms_page_count_total        | store_code             | gauge | Total count of available cms pages                                           |
-| magento_customer_count_total        | store_code             | gauge | Total count of available customer                                            |
-| magento_cronjob_broken_count_total  |                        | gauge | Broken CronJobs occur when when status is pending but execution_time is set. |
-| magento_cronjob_count_total         | status, job_code       | gauge | Total count of available CronJob Count.                                      |
-| magento_indexer_backlog_count_total | isValid, title, status | gauge | Total count of backlog item in indexer.                                      |
+| Metric                              | Labels                          | TYPE  | Help                                                                         |
+|:------------------------------------|:--------------------------------|:------|:-----------------------------------------------------------------------------|
+| magento_orders_count_total          | status, store_code              | gauge | All Magento Orders                                                           |
+| magento_orders_amount_total         | status, store_code              | gauge | Total amount of all Magento Orders                                           |
+| magento_order_items_count_total     | status, store_code              | gauge | Total count of orderitems                                                    |
+| magento_cms_block_count_total       | store_code                      | gauge | Total count of available cms blocks                                          |
+| magento_cms_page_count_total        | store_code                      | gauge | Total count of available cms pages                                           |
+| magento_customer_count_total        | store_code                      | gauge | Total count of available customer                                            |
+| magento_cronjob_broken_count_total  |                                 | gauge | Broken CronJobs occur when when status is pending but execution_time is set. |
+| magento_cronjob_count_total         | status, job_code                | gauge | Total count of available CronJob Count.                                      |
+| magento_indexer_backlog_count_total | isValid, title, status          | gauge | Total count of backlog item in indexer.                                      |
+| magento_shipments_count_total       | source, store_code              | counter| Count of Shipments created by store and source.                             |
+| magento_catalog_category_count_total| status, menu_status, store_code | gauge | Count of Categories by store, status and menu status.                        |
+| magento_store_count_total           | status                          | gauge | Total count of Stores by status.                                             |
+| magento_website_count_total         |                                 | gauge | Total count websites.                                                        |
 
 ## Add you own Metric
 

--- a/Test/Unit/Aggregator/Category/CategoryCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Category/CategoryCountAggregatorTest.php
@@ -18,11 +18,11 @@ use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 final class CategoryCountAggregatorTest extends TestCase
 {
     private const METRIC_CODE = 'magento_catalog_category_count_total';
-    private const T_ATT = 'm2_eav_attribute';
-    private const T_CAT_ENT_INT = 'm2_catalog_category_entity_int';
-    private const T_CAT_ENT = 'm2_catalog_category_entity';
-    private const T_STORE_GROUP = 'm2_store_group';
-    private const T_STORE = 'm2_store';
+    private const TABLE_ATT = 'm2_eav_attribute';
+    private const TABLE_CAT_ENT_INT = 'm2_catalog_category_entity_int';
+    private const TABLE_CAT_ENT = 'm2_catalog_category_entity';
+    private const TABLE_STORE_GROUP = 'm2_store_group';
+    private const TABLE_STORE = 'm2_store';
     private const LINK_FIELD = 'row_id';
     private const ATTR_ID = 77;
 
@@ -90,7 +90,7 @@ final class CategoryCountAggregatorTest extends TestCase
         $select = $this->createMock(Select::class);
 
         $select->expects($this->exactly(3))->method('from')
-               ->withConsecutive([self::T_ATT], [self::T_ATT], [["sg" => self::T_STORE_GROUP]])->willReturn($select);
+               ->withConsecutive([self::TABLE_ATT], [self::TABLE_ATT], [["sg" => self::TABLE_STORE_GROUP]])->willReturn($select);
 
         $select->expects($this->exactly(4))->method('where')
                ->withConsecutive(
@@ -107,15 +107,15 @@ final class CategoryCountAggregatorTest extends TestCase
         $select->expects($this->exactly(3))->method('joinInner')
                ->withConsecutive(
                    [
-                       ['s' => self::T_STORE],
+                       ['s' => self::TABLE_STORE],
                        'sg.group_id = s.group_id'
                    ],
                    [
-                       ['cce1' => self::T_CAT_ENT],
+                       ['cce1' => self::TABLE_CAT_ENT],
                        'sg.root_category_id = cce1.entity_id'
                    ],
                    [
-                       ['cce2' => self::T_CAT_ENT],
+                       ['cce2' => self::TABLE_CAT_ENT],
                        "cce2.path like CONCAT(cce1.path, '%')"
                    ]
                )->willReturn($select);
@@ -123,7 +123,7 @@ final class CategoryCountAggregatorTest extends TestCase
         $select->expects($this->exactly(4))->method('joinLeft')
                ->withConsecutive(
                    [
-                       ['ccei1' => self::T_CAT_ENT_INT],
+                       ['ccei1' => self::TABLE_CAT_ENT_INT],
                        sprintf(
                            "cce2.%s = ccei1.%s AND ccei1.attribute_id = %s AND ccei1.store_id = s.store_id",
                            self::LINK_FIELD,
@@ -132,7 +132,7 @@ final class CategoryCountAggregatorTest extends TestCase
                        )
                    ],
                    [
-                       ['ccei2' => self::T_CAT_ENT_INT],
+                       ['ccei2' => self::TABLE_CAT_ENT_INT],
                        sprintf(
                            "cce2.%s = ccei2.%s AND ccei2.attribute_id = %s AND ccei2.store_id = 0",
                            self::LINK_FIELD,
@@ -141,7 +141,7 @@ final class CategoryCountAggregatorTest extends TestCase
                        )
                    ],
                    [
-                       ['ccei3' => self::T_CAT_ENT_INT],
+                       ['ccei3' => self::TABLE_CAT_ENT_INT],
                        sprintf(
                            "cce2.%s = ccei3.%s AND ccei3.attribute_id = %s AND ccei3.store_id = s.store_id",
                            self::LINK_FIELD,
@@ -150,7 +150,7 @@ final class CategoryCountAggregatorTest extends TestCase
                        )
                    ],
                    [
-                       ['ccei4' => self::T_CAT_ENT_INT],
+                       ['ccei4' => self::TABLE_CAT_ENT_INT],
                        sprintf(
                            "cce2.%s = ccei4.%s AND ccei4.attribute_id = %s AND ccei4.store_id = 0",
                            self::LINK_FIELD,
@@ -206,11 +206,11 @@ final class CategoryCountAggregatorTest extends TestCase
     private function getTableNamesMap(): array
     {
         return [
-            ['eav_attribute', self::T_ATT],
-            ['catalog_category_entity_int', self::T_CAT_ENT_INT],
-            ['catalog_category_entity', self::T_CAT_ENT],
-            ['store', self::T_STORE],
-            ['store_group', self::T_STORE_GROUP],
+            ['eav_attribute', self::TABLE_ATT],
+            ['catalog_category_entity_int', self::TABLE_CAT_ENT_INT],
+            ['catalog_category_entity', self::TABLE_CAT_ENT],
+            ['store', self::TABLE_STORE],
+            ['store_group', self::TABLE_STORE_GROUP],
         ];
     }
 

--- a/Test/Unit/Aggregator/Category/CategoryCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Category/CategoryCountAggregatorTest.php
@@ -1,0 +1,275 @@
+<?php declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Shipment;
+
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\DB\Sql\Expression;
+use Magento\Framework\DB\Sql\ExpressionFactory;
+use Magento\Framework\EntityManager\EntityMetadataInterface;
+use Magento\Framework\EntityManager\MetadataPool;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Category\CategoryCountAggregator;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+final class CategoryCountAggregatorTest extends TestCase
+{
+    private const METRIC_CODE = 'magento_catalog_category_count_total';
+    private const T_ATT = 'm2_eav_attribute';
+    private const T_CAT_ENT_INT = 'm2_catalog_category_entity_int';
+    private const T_CAT_ENT = 'm2_catalog_category_entity';
+    private const T_STORE_GROUP = 'm2_store_group';
+    private const T_STORE = 'm2_store';
+    private const LINK_FIELD = 'row_id';
+    private const ATTR_ID = 77;
+
+    private CategoryCountAggregator $subject;
+
+    /** @var MockObject|UpdateMetricService */
+    private $updateMetricService;
+
+    /** @var MockObject|ResourceConnection */
+    private $resourceConnection;
+
+    /** @var MockObject|ExpressionFactory */
+    private $expressionFactory;
+
+    /** @var MockObject|MetadataPool */
+    private $metadataPool;
+
+    protected function setUp(): void
+    {
+        $this->updateMetricService = $this->createMock(UpdateMetricService::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->expressionFactory = $this->createMock(ExpressionFactory::class);
+        $this->metadataPool = $this->createMock(MetadataPool::class);
+
+        $this->subject = new CategoryCountAggregator(
+            $this->updateMetricService,
+            $this->resourceConnection,
+            $this->metadataPool,
+            $this->expressionFactory
+        );
+    }
+
+    private function getStatisticData(): array
+    {
+        return [
+            [
+                'STORE_CODE' => 'default',
+                'ACTIVE_IN_MENU' => 50,
+                'ACTIVE_NOT_IN_MENU' => 10,
+                'NOT_ACTIVE_IN_MENU' => 25,
+                'NOT_ACTIVE_NOT_IN_MENU' => 15
+
+            ],
+            [
+                'STORE_CODE' => 'base',
+                'ACTIVE_IN_MENU' => 18,
+                'ACTIVE_NOT_IN_MENU' => 3,
+                'NOT_ACTIVE_IN_MENU' => 4,
+                'NOT_ACTIVE_NOT_IN_MENU' => 1
+
+            ],
+            [
+                'STORE_CODE' => 'eu',
+                'ACTIVE_IN_MENU' => 79,
+                'ACTIVE_NOT_IN_MENU' => 21,
+                'NOT_ACTIVE_IN_MENU' => 15,
+                'NOT_ACTIVE_NOT_IN_MENU' => 16
+
+            ],
+        ];
+    }
+
+    private function getSelectMock(): MockObject
+    {
+        $select = $this->createMock(Select::class);
+
+        $select->expects($this->exactly(3))->method('from')
+               ->withConsecutive([self::T_ATT], [self::T_ATT], [["sg" => self::T_STORE_GROUP]])->willReturn($select);
+
+        $select->expects($this->exactly(4))->method('where')
+               ->withConsecutive(
+                   ['entity_type_id = ?', 3],
+                   ['attribute_code = ?', 'is_active'],
+                   ['entity_type_id = ?', 3],
+                   ['attribute_code = ?', 'include_in_menu'],
+               )->willReturn($select);
+        $select->expects($this->exactly(3))
+               ->method('reset')
+               ->with(Select::COLUMNS)
+               ->willReturn($select);
+
+        $select->expects($this->exactly(3))->method('joinInner')
+               ->withConsecutive(
+                   [
+                       ['s' => self::T_STORE],
+                       'sg.group_id = s.group_id'
+                   ],
+                   [
+                       ['cce1' => self::T_CAT_ENT],
+                       'sg.root_category_id = cce1.entity_id'
+                   ],
+                   [
+                       ['cce2' => self::T_CAT_ENT],
+                       "cce2.path like CONCAT(cce1.path, '%')"
+                   ]
+               )->willReturn($select);
+
+        $select->expects($this->exactly(4))->method('joinLeft')
+               ->withConsecutive(
+                   [
+                       ['ccei1' => self::T_CAT_ENT_INT],
+                       sprintf(
+                           "cce2.%s = ccei1.%s AND ccei1.attribute_id = %s AND ccei1.store_id = s.store_id",
+                           self::LINK_FIELD,
+                           self::LINK_FIELD,
+                           self::ATTR_ID
+                       )
+                   ],
+                   [
+                       ['ccei2' => self::T_CAT_ENT_INT],
+                       sprintf(
+                           "cce2.%s = ccei2.%s AND ccei2.attribute_id = %s AND ccei2.store_id = 0",
+                           self::LINK_FIELD,
+                           self::LINK_FIELD,
+                           self::ATTR_ID
+                       )
+                   ],
+                   [
+                       ['ccei3' => self::T_CAT_ENT_INT],
+                       sprintf(
+                           "cce2.%s = ccei3.%s AND ccei3.attribute_id = %s AND ccei3.store_id = s.store_id",
+                           self::LINK_FIELD,
+                           self::LINK_FIELD,
+                           self::ATTR_ID
+                       )
+                   ],
+                   [
+                       ['ccei4' => self::T_CAT_ENT_INT],
+                       sprintf(
+                           "cce2.%s = ccei4.%s AND ccei4.attribute_id = %s AND ccei4.store_id = 0",
+                           self::LINK_FIELD,
+                           self::LINK_FIELD,
+                           self::ATTR_ID
+                       )
+                   ]
+               )->willReturn($select);
+
+        $expressionMock = $this->createMock(Expression::class);
+        $this->expressionFactory->expects($this->exactly(4))
+                                ->method('create')
+                                ->willReturnMap($this->getExpressionsMap($expressionMock));
+        $select->expects($this->exactly(3))->method('columns')
+               ->withConsecutive(
+                   [
+                       ['attribute_id']
+                   ],
+                   [
+                       ['attribute_id']
+                   ],
+                   [
+                       [
+                           'STORE_CODE' => 's.code',
+                           'ACTIVE_IN_MENU' => $expressionMock,
+                           'ACTIVE_NOT_IN_MENU' => $expressionMock,
+                           'NOT_ACTIVE_IN_MENU' => $expressionMock,
+                           'NOT_ACTIVE_NOT_IN_MENU' => $expressionMock
+                       ]
+                   ]
+               )->willReturn($select);
+
+        $select->expects($this->once())->method('group')->with('s.code');
+
+        return $select;
+    }
+
+    private function getExpressionsMap(Expression $expressionMock): array
+    {
+        $expression = 'COUNT((
+            %s IF(ccei1.value IS NULL, ccei2.value, ccei1.value) AND
+            %s IF(ccei3.value IS NULL, ccei4.value, ccei3.value)
+        ) or null)';
+
+        return [
+            [['expression' => sprintf($expression, '', '')], $expressionMock],
+            [['expression' => sprintf($expression, '', 'NOT')], $expressionMock],
+            [['expression' => sprintf($expression, 'NOT', '')], $expressionMock],
+            [['expression' => sprintf($expression, 'NOT', 'NOT')], $expressionMock],
+        ];
+    }
+
+    private function getTableNamesMap(): array
+    {
+        return [
+            ['eav_attribute', self::T_ATT],
+            ['catalog_category_entity_int', self::T_CAT_ENT_INT],
+            ['catalog_category_entity', self::T_CAT_ENT],
+            ['store', self::T_STORE],
+            ['store_group', self::T_STORE_GROUP],
+        ];
+    }
+
+    public function testAggregate(): void
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $statisticData = $this->getStatisticData();
+        $this->resourceConnection->expects($this->once())->method('getConnection')->willReturn($connection);
+        $connection->expects($this->exactly(10))
+                   ->method('getTableName')
+                   ->willReturnMap($this->getTableNamesMap());
+        $entityMetadata = $this->createMock(EntityMetadataInterface::class);
+        $entityMetadata->expects($this->once())->method('getLinkField')->willReturn(self::LINK_FIELD);
+        $this->metadataPool->expects($this->once())->method('getMetadata')
+                           ->with(CategoryInterface::class)->willReturn($entityMetadata);
+
+        $select = $this->getSelectMock();
+        $connection->expects($this->exactly(3))->method('select')->willReturn($select);
+        $connection->expects($this->exactly(2))->method('fetchOne')->willReturn(self::ATTR_ID);
+        $connection->expects($this->once())
+                   ->method('fetchAll')
+                   ->with($select)
+                   ->willReturn($statisticData);
+
+        $this->updateMetricService->expects($this->exactly(4 * count($statisticData)))
+                                  ->method('update')
+                                  ->withConsecutive(...$this->getUpdateMetricsArguments($statisticData));
+
+        $this->subject->aggregate();
+    }
+
+    private function getUpdateMetricsArguments(array $statisticData): array
+    {
+        $arguments = [];
+
+        foreach ($statisticData as $datum) {
+            $label = ['store_code' => $datum['STORE_CODE']];
+            $arguments[] = [
+                self::METRIC_CODE,
+                $datum['ACTIVE_IN_MENU'],
+                array_merge(['status' => 'enabled', 'menu_status' => 'enabled'], $label)
+            ];
+            $arguments[] = [
+                self::METRIC_CODE,
+                $datum['ACTIVE_NOT_IN_MENU'],
+                array_merge(['status' => 'enabled', 'menu_status' => 'disabled'], $label)
+            ];
+            $arguments[] = [
+                self::METRIC_CODE,
+                $datum['NOT_ACTIVE_IN_MENU'],
+                array_merge(['status' => 'disabled', 'menu_status' => 'enabled'], $label)
+            ];
+            $arguments[] = [
+                self::METRIC_CODE,
+                $datum['NOT_ACTIVE_NOT_IN_MENU'],
+                array_merge(['status' => 'disabled', 'menu_status' => 'disabled'], $label)
+            ];
+        }
+
+        return $arguments;
+    }
+}

--- a/Test/Unit/Aggregator/Shipment/ShipmentCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Shipment/ShipmentCountAggregatorTest.php
@@ -78,7 +78,6 @@ final class ShipmentCountAggregatorTest extends TestCase
                        'ss.store_id = s.store_id',
                        ['code']
                    ]
-
                )->willReturn($select);
         $select->expects($this->once())->method('reset')->with(Select::COLUMNS)->willReturn($select);
         $select->expects($this->once())->method('group')->with(['s.code', 'iss.source_code']);

--- a/Test/Unit/Aggregator/Shipment/ShipmentCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Shipment/ShipmentCountAggregatorTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Shipment;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Shipment\ShipmentCountAggregator;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+final class ShipmentCountAggregatorTest extends TestCase
+{
+    private const METRIC_CODE = 'magento_shipments_count_total';
+    private const T_SHIP = 'm2_sales_shipment';
+    private const T_INV_SHIP = 'm2_inventory_shipment_source';
+    private const T_STORE = 'm2_store';
+
+    private ShipmentCountAggregator $subject;
+
+    /** @var MockObject|UpdateMetricService */
+    private $updateMetricService;
+
+    /** @var MockObject|ResourceConnection */
+    private $resourceConnection;
+
+    protected function setUp(): void
+    {
+        $this->updateMetricService = $this->createMock(UpdateMetricService::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+
+        $this->subject = new ShipmentCountAggregator(
+            $this->updateMetricService,
+            $this->resourceConnection
+        );
+    }
+
+    private function getStatisticData(): array
+    {
+        return [
+            [
+                'SHIPMENT_COUNT' => 111,
+                'STORE_CODE' => 'default',
+                'SOURCE_CODE' => 'default'
+            ],
+            [
+                'SHIPMENT_COUNT' => 222,
+                'STORE_CODE' => 'default',
+                'SOURCE_CODE' => 'eu'
+            ],
+            [
+                'SHIPMENT_COUNT' => 333,
+                'STORE_CODE' => 'nl',
+                'SOURCE_CODE' => 'eu'
+            ]
+        ];
+    }
+
+    private function getSelectMock(): MockObject
+    {
+        $select = $this->createMock(Select::class);
+        $select->expects($this->once())
+               ->method('from')
+               ->with(['ss' => self::T_SHIP])
+               ->willReturn($select);
+
+        $select->expects($this->exactly(2))
+               ->method('joinInner')
+               ->withConsecutive(
+                   [
+                       ['iss' => self::T_INV_SHIP],
+                       'ss.entity_id = iss.shipment_id',
+                       ['source_code']
+                   ],
+                   [
+                       ['s' => self::T_STORE],
+                       'ss.store_id = s.store_id',
+                       ['code']
+                   ]
+
+               )->willReturn($select);
+        $select->expects($this->once())->method('reset')->with(Select::COLUMNS)->willReturn($select);
+        $select->expects($this->once())->method('group')->with(['s.code', 'iss.source_code']);
+        $select->expects($this->once())
+               ->method('columns')
+               ->with(
+                   [
+                       'SHIPMENT_COUNT' => 'COUNT(ss.entity_id)',
+                       'STORE_CODE' => 's.code',
+                       'SOURCE_CODE' => 'iss.source_code'
+                   ]
+               )->willReturn($select);
+
+        return $select;
+    }
+
+    public function testAggregate(): void
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $statisticData = $this->getStatisticData();
+        $select = $this->getSelectMock();
+
+        $this->resourceConnection->expects($this->once())
+                                 ->method('getConnection')
+                                 ->with('sales')
+                                 ->willReturn($connection);
+        $connection->expects($this->once())->method('select')->willReturn($select);
+        $connection->expects($this->once())->method('fetchAll')->with($select)->willReturn($statisticData);
+        $connection->expects($this->exactly(3))
+                   ->method('getTableName')
+                   ->willReturnMap(
+                       [
+                           ['sales_shipment', self::T_SHIP],
+                           ['inventory_shipment_source', self::T_INV_SHIP],
+                           ['store', self::T_STORE]
+                       ]
+                   );
+
+        $params = [];
+        foreach ($statisticData as $datum) {
+            $params[] = [
+                self::METRIC_CODE,
+                $datum['SHIPMENT_COUNT'],
+                ['source' => $datum['SOURCE_CODE'], 'store_code' => $datum['STORE_CODE']]
+            ];
+        }
+
+        $this->updateMetricService->expects($this->exactly(3))
+                                  ->method('update')
+                                  ->withConsecutive(...$params);
+
+        $this->subject->aggregate();
+    }
+}

--- a/Test/Unit/Aggregator/Shipment/ShipmentCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Shipment/ShipmentCountAggregatorTest.php
@@ -13,9 +13,9 @@ use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 final class ShipmentCountAggregatorTest extends TestCase
 {
     private const METRIC_CODE = 'magento_shipments_count_total';
-    private const T_SHIP = 'm2_sales_shipment';
-    private const T_INV_SHIP = 'm2_inventory_shipment_source';
-    private const T_STORE = 'm2_store';
+    private const TABLE_SHIP = 'm2_sales_shipment';
+    private const TABLE_INV_SHIP = 'm2_inventory_shipment_source';
+    private const TABLE_STORE = 'm2_store';
 
     private ShipmentCountAggregator $subject;
 
@@ -62,19 +62,19 @@ final class ShipmentCountAggregatorTest extends TestCase
         $select = $this->createMock(Select::class);
         $select->expects($this->once())
                ->method('from')
-               ->with(['ss' => self::T_SHIP])
+               ->with(['ss' => self::TABLE_SHIP])
                ->willReturn($select);
 
         $select->expects($this->exactly(2))
                ->method('joinInner')
                ->withConsecutive(
                    [
-                       ['iss' => self::T_INV_SHIP],
+                       ['iss' => self::TABLE_INV_SHIP],
                        'ss.entity_id = iss.shipment_id',
                        ['source_code']
                    ],
                    [
-                       ['s' => self::T_STORE],
+                       ['s' => self::TABLE_STORE],
                        'ss.store_id = s.store_id',
                        ['code']
                    ]
@@ -110,9 +110,9 @@ final class ShipmentCountAggregatorTest extends TestCase
                    ->method('getTableName')
                    ->willReturnMap(
                        [
-                           ['sales_shipment', self::T_SHIP],
-                           ['inventory_shipment_source', self::T_INV_SHIP],
-                           ['store', self::T_STORE]
+                           ['sales_shipment', self::TABLE_SHIP],
+                           ['inventory_shipment_source', self::TABLE_INV_SHIP],
+                           ['store', self::TABLE_STORE]
                        ]
                    );
 

--- a/Test/Unit/Aggregator/Store/StoreCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Store/StoreCountAggregatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Module;
 
+use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -12,6 +13,8 @@ use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 
 final class StoreCountAggregatorTest extends TestCase
 {
+    private const METRIC_CODE = 'magento_store_count_total';
+
     /** @var StoreCountAggregator */
     private $sut;
 
@@ -21,7 +24,7 @@ final class StoreCountAggregatorTest extends TestCase
     /** @var MockObject|StoreRepositoryInterface */
     private $storeRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->updateMetricService = $this->createMock(UpdateMetricService::class);
         $this->storeRepository     = $this->createMock(StoreRepositoryInterface::class);
@@ -34,15 +37,26 @@ final class StoreCountAggregatorTest extends TestCase
 
     public function testAggregate(): void
     {
+        $store1 = $this->createMock(StoreInterface::class);
+        $store2 = $this->createMock(StoreInterface::class);
+        $store3 = $this->createMock(StoreInterface::class);
+
+        $store1->expects($this->once())->method('getIsActive')->willReturn(1);
+        $store2->expects($this->once())->method('getIsActive')->willReturn(0);
+        $store3->expects($this->once())->method('getIsActive')->willReturn(1);
+
         $this->storeRepository
             ->expects($this->once())
             ->method('getList')
-            ->willReturn(['a', 'b', 'c']);
+            ->willReturn([$store1, $store2, $store3]);
 
         $this->updateMetricService
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('update')
-            ->with(...['magento_store_count_total', '3']);
+            ->withConsecutive(
+                [self::METRIC_CODE, '2', ['status' => 'enabled']],
+                [self::METRIC_CODE, '1', ['status' => 'disabled']],
+            );
 
         $this->sut->aggregate();
     }

--- a/Test/Unit/Aggregator/Store/WebsiteCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Store/WebsiteCountAggregatorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Store;
+
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Store\WebsiteCountAggregator;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+final class WebsiteCountAggregatorTest extends TestCase
+{
+    private const METRIC_CODE = 'magento_website_count_total';
+
+    private WebsiteCountAggregator $sut;
+
+    /** @var MockObject|UpdateMetricService */
+    private $updateMetricService;
+
+    /** @var MockObject|WebsiteRepositoryInterface */
+    private $websiteRepository;
+
+    protected function setUp(): void
+    {
+        $this->updateMetricService = $this->createMock(UpdateMetricService::class);
+        $this->websiteRepository = $this->createMock(WebsiteRepositoryInterface::class);
+
+        $this->sut = new WebsiteCountAggregator(
+            $this->updateMetricService,
+            $this->websiteRepository
+        );
+    }
+
+    public function testAggregate(): void
+    {
+        $this->websiteRepository
+            ->expects($this->once())
+            ->method('getList')
+            ->willReturn(['a', 'b', 'c', 'd', '3']);
+
+        $this->updateMetricService
+            ->expects($this->once())
+            ->method('update')
+            ->with(self::METRIC_CODE, '5');
+
+        $this->sut->aggregate();
+    }
+}

--- a/src/Aggregator/Category/CategoryCountAggregator.php
+++ b/src/Aggregator/Category/CategoryCountAggregator.php
@@ -142,24 +142,23 @@ class CategoryCountAggregator implements MetricAggregatorInterface
                 )->joinInner(
                 ['cce2' => $connection->getTableName('catalog_category_entity')],
                 "cce2.path like CONCAT(cce1.path, '%')"
-            )->joinLeft(
-                ['ccei1' => $connection->getTableName('catalog_category_entity_int')],
-                "cce2.$linkField = ccei1.$linkField AND " .
-                "ccei1.attribute_id = $isActive AND ccei1.store_id = s.store_id"
-            )->joinLeft(
-                ['ccei2' => $connection->getTableName('catalog_category_entity_int')],
-                "cce2.$linkField = ccei2.$linkField AND " .
-                "ccei2.attribute_id = $isActive AND ccei2.store_id = 0"
-            )->joinLeft(
-                ['ccei3' => $connection->getTableName('catalog_category_entity_int')],
-                "cce2.$linkField = ccei3.$linkField AND " .
-                "ccei3.attribute_id = $isInMenu AND ccei3.store_id = s.store_id"
-            )->joinLeft(
-                ['ccei4' => $connection->getTableName('catalog_category_entity_int')],
-                "cce2.$linkField = ccei4.$linkField AND " .
-                "ccei4.attribute_id = $isInMenu AND ccei4.store_id = 0"
-            )->reset(Select::COLUMNS)
-               ->columns(
+                )->joinLeft(
+                    ['ccei1' => $connection->getTableName('catalog_category_entity_int')],
+                    "cce2.$linkField = ccei1.$linkField AND " .
+                    "ccei1.attribute_id = $isActive AND ccei1.store_id = s.store_id"
+                )->joinLeft(
+                    ['ccei2' => $connection->getTableName('catalog_category_entity_int')],
+                    "cce2.$linkField = ccei2.$linkField AND " .
+                    "ccei2.attribute_id = $isActive AND ccei2.store_id = 0"
+                )->joinLeft(
+                    ['ccei3' => $connection->getTableName('catalog_category_entity_int')],
+                    "cce2.$linkField = ccei3.$linkField AND " .
+                    "ccei3.attribute_id = $isInMenu AND ccei3.store_id = s.store_id"
+                )->joinLeft(
+                    ['ccei4' => $connection->getTableName('catalog_category_entity_int')],
+                    "cce2.$linkField = ccei4.$linkField AND " .
+                    "ccei4.attribute_id = $isInMenu AND ccei4.store_id = 0"
+                )->reset(Select::COLUMNS)->columns(
                    [
                        'STORE_CODE' => 's.code',
                        'ACTIVE_IN_MENU' => $activeInMenu,

--- a/src/Aggregator/Category/CategoryCountAggregator.php
+++ b/src/Aggregator/Category/CategoryCountAggregator.php
@@ -1,0 +1,197 @@
+<?php declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Aggregator\Category;
+
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\DB\Sql\ExpressionFactory;
+use Magento\Framework\EntityManager\MetadataPool;
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+class CategoryCountAggregator implements MetricAggregatorInterface
+{
+    private const METRIC_CODE = 'magento_catalog_category_count_total';
+    private const CATEGORY_ENTITY_ID = 3;
+
+    private UpdateMetricService $updateMetricService;
+
+    private ResourceConnection $resourceConnection;
+
+    private MetadataPool $metadataPool;
+
+    private ExpressionFactory $expressionFactory;
+
+    /**
+     * @param UpdateMetricService $updateMetricService
+     * @param ResourceConnection $resourceConnection
+     * @param MetadataPool $metadataPool
+     * @param ExpressionFactory $expressionFactory
+     */
+    public function __construct(
+        UpdateMetricService $updateMetricService,
+        ResourceConnection  $resourceConnection,
+        MetadataPool        $metadataPool,
+        ExpressionFactory   $expressionFactory
+    ) {
+        $this->updateMetricService = $updateMetricService;
+        $this->resourceConnection = $resourceConnection;
+        $this->metadataPool = $metadataPool;
+        $this->expressionFactory = $expressionFactory;
+    }
+
+    public function getCode(): string
+    {
+        return self::METRIC_CODE;
+    }
+
+    public function getHelp(): string
+    {
+        return 'Magento 2 Categories count by status and store code.';
+    }
+
+    public function getType(): string
+    {
+        return 'gauge';
+    }
+
+    public function aggregate(): bool
+    {
+        $connection = $this->resourceConnection->getConnection();
+
+        $data = $connection->fetchAll($this->getSelect($connection));
+
+        foreach ($data as $datum) {
+            $labels = ['store_code' => $datum['STORE_CODE']];
+
+            $this->updateMetrics(
+                (string)$datum['ACTIVE_IN_MENU'],
+                array_merge($labels, ['status' => 'enabled', 'menu_status' => 'enabled'])
+            );
+            $this->updateMetrics(
+                (string)$datum['ACTIVE_NOT_IN_MENU'],
+                array_merge($labels, ['status' => 'enabled', 'menu_status' => 'disabled'])
+            );
+            $this->updateMetrics(
+                (string)$datum['NOT_ACTIVE_IN_MENU'],
+                array_merge($labels, ['status' => 'disabled', 'menu_status' => 'enabled'])
+            );
+            $this->updateMetrics(
+                (string)$datum['NOT_ACTIVE_NOT_IN_MENU'],
+                array_merge($labels, ['status' => 'disabled', 'menu_status' => 'disabled'])
+            );
+        }
+
+        return true;
+    }
+
+    private function updateMetrics(string $count, array $labels): void
+    {
+        $this->updateMetricService->update(self::METRIC_CODE, $count, $labels);
+    }
+
+    /**
+     * SQL example:
+     * select s.code,
+     * COUNT( (IF (ccei1.value IS NULL, ccei2.value, ccei1.value) AND IF (ccei3.value IS NULL, ccei4.value,
+     * ccei3.value)) or null) as active_in_menu, COUNT( (IF (ccei1.value IS NULL, ccei2.value, ccei1.value) AND NOT IF
+     * (ccei3.value IS NULL, ccei4.value, ccei3.value)) or null) as active_not_in_menu, COUNT( (NOT IF (ccei1.value IS
+     * NULL, ccei2.value, ccei1.value) AND IF (ccei3.value IS NULL, ccei4.value, ccei3.value)) or null) as
+     * disabled_in_menu, COUNT( (NOT IF (ccei1.value IS NULL, ccei2.value, ccei1.value) AND NOT IF (ccei3.value IS
+     * NULL, ccei4.value, ccei3.value)) or null) as disabled_not_in_menu from store_group sg inner join store s on
+     * s.group_id = sg.group_id inner join catalog_category_entity cce1 on sg.root_category_id = cce1.entity_id inner
+     * join catalog_category_entity cce2 on cce2.path like CONCAT(cce1.path, '%') left join catalog_category_entity_int
+     * ccei1 on ccei1.entity_id = cce2.entity_id and ccei1.attribute_id = 32 and ccei1.store_id = s.store_id left join
+     * catalog_category_entity_int ccei2 on ccei2.entity_id = cce2.entity_id and ccei2.attribute_id = 32 and
+     * ccei2.store_id = 0 left join catalog_category_entity_int ccei3 on ccei3.entity_id = cce2.entity_id and ccei3.attribute_id = 601 and ccei3.store_id = s.store_id left join catalog_category_entity_int ccei4 on ccei4.entity_id = cce2.entity_id and ccei4.attribute_id = 601 and ccei4.store_id = 0 group by s.code;
+     *
+     *
+     * @param AdapterInterface $connection
+     *
+     * @return Select
+     * @throws \Exception
+     */
+    private function getSelect(AdapterInterface $connection): Select
+    {
+        $linkField = $this->metadataPool->getMetadata(CategoryInterface::class)->getLinkField();
+        $isActive = $this->getIsActiveAttributeId($connection);
+        $isInMenu = $this->getIsInMenuAttributeId($connection);
+        $expression = 'COUNT((
+            %s IF(ccei1.value IS NULL, ccei2.value, ccei1.value) AND
+            %s IF(ccei3.value IS NULL, ccei4.value, ccei3.value)
+        ) or null)';
+
+        $activeInMenu = $this->expressionFactory->create(['expression' => sprintf($expression, '', '')]);
+        $activeNotInMenu = $this->expressionFactory->create(['expression' => sprintf($expression, '', 'NOT')]);
+        $notActiveInMenu = $this->expressionFactory->create(['expression' => sprintf($expression, 'NOT', '')]);
+        $notActiveNotInMenu = $this->expressionFactory->create(
+            ['expression' => sprintf($expression, 'NOT', 'NOT')]
+        );
+
+        $select = $connection->select();
+
+        $select->from(['sg' => $connection->getTableName('store_group')])
+               ->joinInner(
+                   ['s' => $connection->getTableName('store')],
+                   'sg.group_id = s.group_id'
+               )->joinInner(
+                ['cce1' => $connection->getTableName('catalog_category_entity')],
+                'sg.root_category_id = cce1.entity_id'
+            )->joinInner(
+                ['cce2' => $connection->getTableName('catalog_category_entity')],
+                "cce2.path like CONCAT(cce1.path, '%')"
+            )->joinLeft(
+                ['ccei1' => $connection->getTableName('catalog_category_entity_int')],
+                "cce2.$linkField = ccei1.$linkField AND " .
+                "ccei1.attribute_id = $isActive AND ccei1.store_id = s.store_id"
+            )->joinLeft(
+                ['ccei2' => $connection->getTableName('catalog_category_entity_int')],
+                "cce2.$linkField = ccei2.$linkField AND " .
+                "ccei2.attribute_id = $isActive AND ccei2.store_id = 0"
+            )->joinLeft(
+                ['ccei3' => $connection->getTableName('catalog_category_entity_int')],
+                "cce2.$linkField = ccei3.$linkField AND " .
+                "ccei3.attribute_id = $isInMenu AND ccei3.store_id = s.store_id"
+            )->joinLeft(
+                ['ccei4' => $connection->getTableName('catalog_category_entity_int')],
+                "cce2.$linkField = ccei4.$linkField AND " .
+                "ccei4.attribute_id = $isInMenu AND ccei4.store_id = 0"
+            )->reset(Select::COLUMNS)
+               ->columns(
+                   [
+                       'STORE_CODE' => 's.code',
+                       'ACTIVE_IN_MENU' => $activeInMenu,
+                       'ACTIVE_NOT_IN_MENU' => $activeNotInMenu,
+                       'NOT_ACTIVE_IN_MENU' => $notActiveInMenu,
+                       'NOT_ACTIVE_NOT_IN_MENU' => $notActiveNotInMenu
+                   ]
+               )->group('s.code');
+
+        return $select;
+    }
+
+    private function getIsActiveAttributeId(AdapterInterface $connection): int
+    {
+        return $this->getAttributeId($connection, 'is_active');
+    }
+
+    private function getIsInMenuAttributeId(AdapterInterface $connection): int
+    {
+        return $this->getAttributeId($connection, 'include_in_menu');
+    }
+
+    private function getAttributeId(AdapterInterface $connection, string $code): int
+    {
+        $select = $connection->select();
+
+        $select->from($connection->getTableName('eav_attribute'))
+               ->where('entity_type_id = ?', self::CATEGORY_ENTITY_ID)
+               ->where('attribute_code = ?', $code)
+               ->reset(Select::COLUMNS)
+               ->columns(['attribute_id']);
+
+        return (int)$connection->fetchOne($select);
+    }
+}

--- a/src/Aggregator/Category/CategoryCountAggregator.php
+++ b/src/Aggregator/Category/CategoryCountAggregator.php
@@ -137,9 +137,9 @@ class CategoryCountAggregator implements MetricAggregatorInterface
                    ['s' => $connection->getTableName('store')],
                    'sg.group_id = s.group_id'
                )->joinInner(
-                ['cce1' => $connection->getTableName('catalog_category_entity')],
-                'sg.root_category_id = cce1.entity_id'
-            )->joinInner(
+                    ['cce1' => $connection->getTableName('catalog_category_entity')],
+                    'sg.root_category_id = cce1.entity_id'
+                )->joinInner(
                 ['cce2' => $connection->getTableName('catalog_category_entity')],
                 "cce2.path like CONCAT(cce1.path, '%')"
             )->joinLeft(

--- a/src/Aggregator/Shipment/ShipmentCountAggregator.php
+++ b/src/Aggregator/Shipment/ShipmentCountAggregator.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Aggregator\Shipment;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+class ShipmentCountAggregator implements MetricAggregatorInterface
+{
+    private const METRIC_CODE = 'magento_shipments_count_total';
+
+    private UpdateMetricService $updateMetricService;
+
+    private ResourceConnection $resourceConnection;
+
+    /**
+     * @param UpdateMetricService $updateMetricService
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        UpdateMetricService $updateMetricService,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->updateMetricService = $updateMetricService;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    public function getCode(): string
+    {
+        return self::METRIC_CODE;
+    }
+
+    public function getHelp(): string
+    {
+        return 'Magento 2 Shipments amount by store and source.';
+    }
+
+    public function getType(): string
+    {
+        return 'counter';
+    }
+
+    public function aggregate(): bool
+    {
+        $connection = $this->resourceConnection->getConnection('sales');
+
+        $statistic = $connection->fetchAll($this->getSelect($connection));
+
+        foreach ($statistic as $result) {
+            $count = $result['SHIPMENT_COUNT'] ?? 0;
+            $store = $result['STORE_CODE'] ?? '';
+            $source = $result['SOURCE_CODE'] ?? '';
+
+            $labels = ['source' => $source, 'store_code' => $store];
+
+            $this->updateMetricService->update(self::METRIC_CODE, (string)$count, $labels);
+        }
+
+        return true;
+    }
+
+    private function getSelect(AdapterInterface $connection): Select
+    {
+        $select = $connection->select();
+
+        $select->from(['ss' => $connection->getTableName('sales_shipment')])
+               ->joinInner(
+                   ['iss' => $connection->getTableName('inventory_shipment_source')],
+                   'ss.entity_id = iss.shipment_id',
+                   ['source_code']
+               )->joinInner(
+                ['s' => $connection->getTableName('store')],
+                'ss.store_id = s.store_id',
+                ['code']
+            )->reset(Select::COLUMNS)
+               ->columns(
+                   [
+                       'SHIPMENT_COUNT' => 'COUNT(ss.entity_id)',
+                       'STORE_CODE' => 's.code',
+                       'SOURCE_CODE' => 'iss.source_code'
+                   ]
+               )->group(['s.code', 'iss.source_code']);
+
+        return $select;
+    }
+}

--- a/src/Aggregator/Shipment/ShipmentCountAggregator.php
+++ b/src/Aggregator/Shipment/ShipmentCountAggregator.php
@@ -72,10 +72,10 @@ class ShipmentCountAggregator implements MetricAggregatorInterface
                    'ss.entity_id = iss.shipment_id',
                    ['source_code']
                )->joinInner(
-                ['s' => $connection->getTableName('store')],
-                'ss.store_id = s.store_id',
-                ['code']
-            )->reset(Select::COLUMNS)
+                    ['s' => $connection->getTableName('store')],
+                    'ss.store_id = s.store_id',
+                    ['code']
+                )->reset(Select::COLUMNS)
                ->columns(
                    [
                        'SHIPMENT_COUNT' => 'COUNT(ss.entity_id)',

--- a/src/Aggregator/Shipment/ShipmentCountAggregator.php
+++ b/src/Aggregator/Shipment/ShipmentCountAggregator.php
@@ -35,7 +35,7 @@ class ShipmentCountAggregator implements MetricAggregatorInterface
 
     public function getHelp(): string
     {
-        return 'Magento 2 Shipments amount by store and source.';
+        return 'Magento 2 Shipments count by store and source.';
     }
 
     public function getType(): string

--- a/src/Aggregator/Shipment/ShipmentCountAggregator.php
+++ b/src/Aggregator/Shipment/ShipmentCountAggregator.php
@@ -22,7 +22,7 @@ class ShipmentCountAggregator implements MetricAggregatorInterface
      */
     public function __construct(
         UpdateMetricService $updateMetricService,
-        ResourceConnection $resourceConnection
+        ResourceConnection  $resourceConnection
     ) {
         $this->updateMetricService = $updateMetricService;
         $this->resourceConnection = $resourceConnection;
@@ -72,17 +72,16 @@ class ShipmentCountAggregator implements MetricAggregatorInterface
                    'ss.entity_id = iss.shipment_id',
                    ['source_code']
                )->joinInner(
-                    ['s' => $connection->getTableName('store')],
-                    'ss.store_id = s.store_id',
-                    ['code']
-                )->reset(Select::COLUMNS)
-               ->columns(
-                   [
-                       'SHIPMENT_COUNT' => 'COUNT(ss.entity_id)',
-                       'STORE_CODE' => 's.code',
-                       'SOURCE_CODE' => 'iss.source_code'
-                   ]
-               )->group(['s.code', 'iss.source_code']);
+                ['s' => $connection->getTableName('store')],
+                'ss.store_id = s.store_id',
+                ['code']
+            )->reset(Select::COLUMNS)->columns(
+                [
+                    'SHIPMENT_COUNT' => 'COUNT(ss.entity_id)',
+                    'STORE_CODE' => 's.code',
+                    'SOURCE_CODE' => 'iss.source_code'
+                ]
+            )->group(['s.code', 'iss.source_code']);
 
         return $select;
     }

--- a/src/Aggregator/Store/WebsiteCountAggregator.php
+++ b/src/Aggregator/Store/WebsiteCountAggregator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Aggregator\Store;
+
+use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+class WebsiteCountAggregator implements MetricAggregatorInterface
+{
+    private const METRIC_CODE = 'magento_website_count_total';
+
+    private UpdateMetricService $updateMetricService;
+
+    private WebsiteRepositoryInterface $websiteRepository;
+
+    /**
+     * @param UpdateMetricService $updateMetricService
+     * @param WebsiteRepositoryInterface $websiteRepository
+     */
+    public function __construct(
+        UpdateMetricService $updateMetricService,
+        WebsiteRepositoryInterface $websiteRepository
+    ) {
+        $this->updateMetricService = $updateMetricService;
+        $this->websiteRepository = $websiteRepository;
+    }
+
+    public function getCode(): string
+    {
+        return self::METRIC_CODE;
+    }
+
+    public function getHelp(): string
+    {
+        return 'Magento 2 Website Count.';
+    }
+
+    public function getType(): string
+    {
+        return 'gauge';
+    }
+
+    public function aggregate(): bool
+    {
+        $websiteList = $this->websiteRepository->getList();
+        $websiteCount = (string)count($websiteList);
+
+        return $this->updateMetricService->update(self::METRIC_CODE, $websiteCount);
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -8,6 +8,9 @@
     <type name="RunAsRoot\PrometheusExporter\Metric\MetricAggregatorPool">
         <arguments>
             <argument name="items" xsi:type="array">
+                <!-- Category Aggregator -->
+                <item name="CategoryCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Category\CategoryCountAggregator</item>
+
                 <!-- CMS Aggregator -->
                 <item name="CmsBlockCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Cms\CmsBlockCountAggregator</item>
                 <item name="CmsPagesCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Cms\CmsPagesCountAggregator</item>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -53,6 +53,7 @@
 
                 <!-- Store Aggregator -->
                 <item name="StoreCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Store\StoreCountAggregator</item>
+                <item name="WebsiteCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Store\WebsiteCountAggregator</item>
 
                 <!-- User Aggregator -->
                 <item name="AdminUserCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\User\AdminUserCountAggregator</item>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -36,6 +36,9 @@
                 <item name="OrderItemAmountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Order\OrderItemAmountAggregator</item>
                 <item name="OrderItemCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Order\OrderItemCountAggregator</item>
 
+                <!-- Shipment Aggregator -->
+                <item name="ShipmentCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Shipment\ShipmentCountAggregator</item>
+
                 <!-- Payment Aggregator -->
                 <item name="ActivePaymentMethodsCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Payment\ActivePaymentMethodsCountAggregator</item>
 


### PR DESCRIPTION
Related ticket: 
https://github.com/run-as-root/magento2-prometheus-exporter/issues/24

Metrics added:
- magento_shipments_count_total (source, store_code)
- magento_catalog_category_count_total (status, menu_status, store_code)
- magento_website_count_total

Metrics changed:
- magento_store_count_total -> magento_store_count_total (status)

Adjusted unit tests coverage.
Updated README.md

Points to discuss:
1. **magento_catalog_category_count_total** - currently collects 4 metric for each store:
- category enabled, added to the menu
- category enabled, removed to the menu
- category disabled, added to the menu
- category disabled, removed to the menu

Possible suggestions:
- remove `menu_status` label and collect only category status
- do not collect `menu_status` if category is disabled (= leave only 3 metrics, if category disabled - consider that it won't be showed in the menu).

2. **magento_catalog_category_count_total** - default store (admin) is not included to the statistic.
It will require separated SQL query to fetch data for admin store (e.g. all available categories). Should we collect this data too, or only leave data collection per actual store?