### PR TITLE
Adding store_code as label for magento_active_payment_methods_count_total

### DIFF
--- a/Test/Unit/Aggregator/Payment/ActivePaymentMethodsCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Payment/ActivePaymentMethodsCountAggregatorTest.php
@@ -50,10 +50,20 @@ final class ActivePaymentMethodsCountAggregatorTest extends TestCase
             ->method('getId')
             ->willReturn(1);
 
+        $store1
+            ->expects($this->once())
+            ->method('getCode')
+            ->willReturn('admin');
+
         $store2
             ->expects($this->once())
             ->method('getId')
             ->willReturn(2);
+
+        $store2
+            ->expects($this->once())
+            ->method('getCode')
+            ->willReturn('default');
 
         $this->storeRepository
             ->expects($this->once())
@@ -72,8 +82,14 @@ final class ActivePaymentMethodsCountAggregatorTest extends TestCase
             ->with(...[2])
             ->willReturn(['a']);
 
-        $labels1 = ['store_id' => 1];
-        $labels2 = ['store_id' => 2];
+        $labels1 = [
+            'store_id' => 1,
+            'store_code' => 'admin'
+        ];
+        $labels2 = [
+            'store_id' => 2,
+            'store_code' => 'default'
+        ];
 
         $this->updateMetricService
             ->expects($this->at(0))

--- a/src/Aggregator/Payment/ActivePaymentMethodsCountAggregator.php
+++ b/src/Aggregator/Payment/ActivePaymentMethodsCountAggregator.php
@@ -50,11 +50,15 @@ class ActivePaymentMethodsCountAggregator implements MetricAggregatorInterface
 
         foreach ($storeList as $store) {
             $storeId = $store->getId();
+            $storeCode = $store->getCode();
 
             $activePaymentMethods      = $this->paymentMethodList->getActiveList($storeId);
             $activePaymentMethodsCount = (string)count($activePaymentMethods);
 
-            $labels = ['store_id' => $storeId];
+            $labels = [
+                'store_id' => $storeId,
+                'store_code' => $storeCode
+            ];
 
             $this->updateMetricService->update(self::METRIC_CODE, $activePaymentMethodsCount, $labels);
         }


### PR DESCRIPTION
I'm not sure why, but "magento_active_payment_methods_count_total" is missing the "store_code". However, other metrics do have this label.

Let me know what you think about adding it.