### PR TITLE
Fix BrokenCronJobCountAggregator

### DIFF
--- a/Test/Unit/Aggregator/Cronjob/BrokenCronJobCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Cronjob/BrokenCronJobCountAggregatorTest.php
@@ -43,18 +43,18 @@ class BrokenCronJobCountAggregatorTest extends TestCase
     {
         $this->collection
             ->expects($this->at(0))
-            ->method('addFilter')
+            ->method('addFieldToFilter')
             ->with(...['status', 'pending'])
             ->willReturn($this->collection);
         $this->collection
             ->expects($this->at(1))
-            ->method('addFilter')
-            ->with(...['executed_at', 'NULL', 'IS NOT'])
+            ->method('addFieldToFilter')
+            ->with(...['executed_at', ['notnull' => true]])
             ->willReturn($this->collection);
         $this->collection
             ->expects($this->at(2))
-            ->method('addFilter')
-            ->with(...['finished_at', 'NULL', 'IS'])
+            ->method('addFieldToFilter')
+            ->with(...['finished_at', ['null' => true]])
             ->willReturn($this->collection);
 
         $this->collection

--- a/Test/Unit/Aggregator/Cronjob/CronJobCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Cronjob/CronJobCountAggregatorTest.php
@@ -27,7 +27,7 @@ class CronJobCountAggregatorTest extends TestCase
     /** @var MockObject|Collection */
     private $collection;
 
-    /** @var BrokenCronJobCountAggregator */
+    /** @var CronJobCountAggregator */
     private $sut;
 
     public function setUp(): void

--- a/src/Aggregator/CronJob/BrokenCronJobCountAggregator.php
+++ b/src/Aggregator/CronJob/BrokenCronJobCountAggregator.php
@@ -47,9 +47,9 @@ TAG;
     {
         /** @var Collection $collection */
         $collection = $this->cronCollectionFactory->create();
-        $collection->addFilter('status', Schedule::STATUS_PENDING)
-            ->addFilter('executed_at', 'NULL', 'IS NOT')
-            ->addFilter('finished_at', 'NULL', 'IS');
+        $collection->addFieldToFilter('status', Schedule::STATUS_PENDING)
+            ->addFieldToFilter('executed_at', ['notnull' => true])
+            ->addFieldToFilter('finished_at', ['null' => true]);
         $this->updateMetricService->update($this->getCode(), (string)$collection->count());
 
         return true;


### PR DESCRIPTION
Fixed an error in the logs:

```
[2024-11-04T11:23:07.622790+00:00] rar_prometheus_metric_logger.ERROR: AggregateMetricsCron: Unable to process jobCode:magento_cronjob_broken_count_total SQLSTATE[HY000]: General error: 1525 Incorrect TIMESTAMP value: 'NULL', query was: SELECT `main_table`.* FROM `cron_schedule` AS `main_table` WHERE (status='pending') AND (executed_at='NULL') AND (finished_at='NULL') [] []
```

There are no `IS` and `IS NOT` filter types.: https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php#L571-L585