### PR TITLE
Fix #48: Add support for database table prefixes

### DIFF
--- a/src/Aggregator/Customer/CustomerAddressesCountAggregator.php
+++ b/src/Aggregator/Customer/CustomerAddressesCountAggregator.php
@@ -40,7 +40,8 @@ class CustomerAddressesCountAggregator implements MetricAggregatorInterface
     {
         $connection = $this->resourceConnection->getConnection();
 
-        $query = 'SELECT ' . 'COUNT(*) FROM customer_address_entity';
+        $tableName = $connection->getTableName('customer_address_entity');
+        $query = 'SELECT COUNT(*) FROM ' . $tableName;
 
         $customerAssociatedAddressCount = (int)$connection->fetchOne($query);
 

--- a/src/Aggregator/Customer/CustomerCountAggregator.php
+++ b/src/Aggregator/Customer/CustomerCountAggregator.php
@@ -39,9 +39,13 @@ class CustomerCountAggregator implements MetricAggregatorInterface
     public function aggregate(): bool
     {
         $connection = $this->resourceConnection->getConnection();
-        $query = 'SELECT ' . 'COUNT(*) AS CUSTOMER_COUNT, STORE.`code` AS STORE_CODE' .
-            ' FROM customer_entity AS CUSTOMERS' .
-            ' INNER JOIN store AS STORE' .
+        $customerEntityTable = $connection->getTableName('customer_entity');
+        
+        $storeTable = $connection->getTableName('store');
+
+        $query = 'SELECT COUNT(*) AS CUSTOMER_COUNT, STORE.`code` AS STORE_CODE' .
+            ' FROM ' . $customerEntityTable . ' AS CUSTOMERS' .
+            ' INNER JOIN ' . $storeTable . ' AS STORE' .
             ' ON CUSTOMERS.`store_id` = STORE.`store_id`' .
             ' GROUP BY STORE.`store_id`';
 

--- a/src/Aggregator/Customer/CustomerGroupCountAggregator.php
+++ b/src/Aggregator/Customer/CustomerGroupCountAggregator.php
@@ -41,7 +41,9 @@ class CustomerGroupCountAggregator implements MetricAggregatorInterface
     {
         $connection = $this->resourceConnection->getConnection();
 
-        $query = 'SELECT ' . 'COUNT(*) FROM customer_group';
+        $tableName = $connection->getTableName('customer_group');
+        
+        $query = 'SELECT COUNT(*) FROM ' . $tableName;
 
         $totalGroup = (int)$connection->fetchOne($query);
 

--- a/src/Aggregator/Eav/AttributeCountAggregator.php
+++ b/src/Aggregator/Eav/AttributeCountAggregator.php
@@ -51,7 +51,8 @@ class AttributeCountAggregator implements MetricAggregatorInterface
 
     public function aggregate(): bool
     {
-        $select     = 'SELECT entity_type_code FROM eav_entity_type;';
+        $tableName = $this->connection->getConnection()->getTableName('eav_entity_type'); 
+        $select = 'SELECT entity_type_code FROM ' . $tableName;
         $eavTypes   = $this->connection->getConnection()->fetchAll($select);
         $totalCount = 0;
 

--- a/src/Aggregator/Order/OrderAmountAggregator.php
+++ b/src/Aggregator/Order/OrderAmountAggregator.php
@@ -55,7 +55,8 @@ class OrderAmountAggregator implements MetricAggregatorInterface
 
         $connection = $this->resourceConnection->getConnection();
 
-        $query = 'SELECT ' . 'SUM(ORDER.grand_total) AS GRAND_TOTAL, ORDER.state AS ORDER_STATE, STORE.code AS STORE_CODE' .
+        $salesOrderTable = $connection->getTableName('sales_order'); 
+        $storeTable = $connection->getTableName('store');        $query = 'SELECT SUM(ORDER.grand_total) AS GRAND_TOTAL, ORDER.state AS ORDER_STATE, STORE.code AS STORE_CODE' .
             ' FROM `sales_order` AS `ORDER`' .
             ' INNER JOIN `store` AS `STORE`' .
             ' ON ORDER.store_id = STORE.store_id' .

--- a/src/Aggregator/Order/OrderCountAggregator.php
+++ b/src/Aggregator/Order/OrderCountAggregator.php
@@ -55,7 +55,8 @@ class OrderCountAggregator implements MetricAggregatorInterface
 
         $connection = $this->resourceConnection->getConnection();
 
-        $query = 'SELECT ' . 'COUNT(*) AS ORDER_COUNT, ORDER.state AS ORDER_STATE, STORE.code AS STORE_CODE' .
+        $salesOrderTable = $connection->getTableName('sales_order'); 
+        $storeTable = $connection->getTableName('store');        $query = 'SELECT COUNT(*) AS ORDER_COUNT, ORDER.state AS ORDER_STATE, STORE.code AS STORE_CODE' .
             ' FROM `sales_order` AS `ORDER`' .
             ' INNER JOIN `store` AS `STORE`' .
             ' ON ORDER.store_id = STORE.store_id' .

--- a/src/Aggregator/Order/OrderItemAmountAggregator.php
+++ b/src/Aggregator/Order/OrderItemAmountAggregator.php
@@ -50,10 +50,11 @@ class OrderItemAmountAggregator implements MetricAggregatorInterface
     {
         $connection = $this->resourceConnection->getConnection();
 
-        $query = 'SELECT ' . 'sales_order.entity_id AS ORDER_ID, store.code AS STORE_CODE' .
-            ' FROM sales_order' .
-            ' INNER JOIN store' .
-            ' ON sales_order.`store_id` = store.store_id';
+        $salesOrderTable = $connection->getTableName('sales_order'); 
+        $storeTable = $connection->getTableName('store');        $query = 'SELECT ' . $salesOrderTable . '.entity_id AS ORDER_ID, ' . $storeTable . '.code AS STORE_CODE' .
+            ' FROM ' . $salesOrderTable .
+            ' INNER JOIN ' . $storeTable .
+            ' ON ' . $salesOrderTable . '.`store_id` = ' . $storeTable . '.store_id';
 
         $ordersAndStores = $connection->fetchAll($query);
 

--- a/src/Aggregator/Order/OrderItemCountAggregator.php
+++ b/src/Aggregator/Order/OrderItemCountAggregator.php
@@ -48,10 +48,11 @@ class OrderItemCountAggregator implements MetricAggregatorInterface
     {
         $connection = $this->resourceConnection->getConnection();
 
-        $query = 'SELECT ' . 'sales_order.entity_id AS ORDER_ID, store.code AS STORE_CODE' .
-            ' FROM sales_order' .
-            ' INNER JOIN store' .
-            ' ON sales_order.`store_id` = store.store_id';
+        $salesOrderTable = $connection->getTableName('sales_order'); 
+        $storeTable = $connection->getTableName('store');        $query = 'SELECT ' . $salesOrderTable . '.entity_id AS ORDER_ID, ' . $storeTable . '.code AS STORE_CODE' .
+            ' FROM ' . $salesOrderTable .
+            ' INNER JOIN ' . $storeTable .
+            ' ON ' . $salesOrderTable . '.`store_id` = ' . $storeTable . '.store_id';
 
         $ordersAndStores = $connection->fetchAll($query);
 

--- a/src/Aggregator/Product/ProductCountAggregator.php
+++ b/src/Aggregator/Product/ProductCountAggregator.php
@@ -38,7 +38,8 @@ class ProductCountAggregator implements MetricAggregatorInterface
 
     public function aggregate(): bool
     {
-        $select       = 'SELECT COUNT(entity_id) as ProductCount FROM catalog_product_entity;';
+        $tableName = $this->connection->getConnection()->getTableName('catalog_product_entity'); 
+        $select = 'SELECT COUNT(entity_id) as ProductCount FROM ' . $tableName;
         $productCount = $this->connection->getConnection()->fetchOne($select);
 
         return $this->updateMetricService->update(self::METRIC_CODE, $productCount);

--- a/src/Aggregator/User/AdminUserCountAggregator.php
+++ b/src/Aggregator/User/AdminUserCountAggregator.php
@@ -41,7 +41,8 @@ class AdminUserCountAggregator implements MetricAggregatorInterface
 
     public function aggregate(): bool
     {
-        $select       = 'SELECT COUNT(user_id) FROM admin_user WHERE is_active = 1;';
+        $tableName = $this->connection->getConnection()->getTableName('admin_user'); 
+        $select = 'SELECT COUNT(user_id) FROM ' . $tableName . ' WHERE is_active = 1';
         $productCount = $this->connection->getConnection()->fetchOne($select);
 
         return $this->updateMetricService->update(self::METRIC_CODE, $productCount);


### PR DESCRIPTION
This commit resolves the issue where Magento installations with database table prefixes (e.g., 'm2_') would fail because aggregators used hardcoded table names in SQL queries.

Changes:
- Updated all aggregators to use ResourceConnection::getTableName() method
- This method automatically handles table prefixes configured in Magento
- Affects the following aggregators:
  * CustomerAddressesCountAggregator
  * CustomerCountAggregator
  * CustomerGroupCountAggregator
  * ProductCountAggregator
  * AdminUserCountAggregator
  * AttributeCountAggregator
  * OrderCountAggregator
  * OrderAmountAggregator
  * OrderItemCountAggregator
  * OrderItemAmountAggregator

The fix ensures that metrics collection works correctly on Magento installations with any configured database table prefix.

Fixes #48