### PR TITLE
fix property type definition

### DIFF
--- a/src/Repository/MetricRepository.php
+++ b/src/Repository/MetricRepository.php
@@ -25,7 +25,7 @@ class MetricRepository implements MetricRepositoryInterface
     private MetricFactory $metricFactory;
     private MetricResource $metricResource;
     private MetricCollectionFactory $collectionFactory;
-    private MetricSearchResultsInterfaceFactory $searchResultsFactory;
+    private SearchResultsInterfaceFactory $searchResultsFactory;
 
     public function __construct(
         MetricResource $metricResource,


### PR DESCRIPTION
In https://github.com/run-as-root/magento2-prometheus-exporter/blob/36e452c7c4b2759005dfada08020fac677a399a5/src/Repository/MetricRepository.php#L28 the property `$searchResultsFactory` is currently defined as `MetricSearchResultsInterfaceFactory` but in constructor definition it is defined as `SearchResultsInterfaceFactory` see https://github.com/run-as-root/magento2-prometheus-exporter/blob/36e452c7c4b2759005dfada08020fac677a399a5/src/Repository/MetricRepository.php#L34