### PR TITLE
docs: add 2026-04 maintenance plan

### DIFF
--- a/docs/plans/2026-04-19-maintenance-plan-design.md
+++ b/docs/plans/2026-04-19-maintenance-plan-design.md
@@ -1,0 +1,187 @@
+# Maintenance Plan — Security, CI, and Open Issues
+
+**Date:** 2026-04-19
+**Scope:** Close two open Dependabot alerts, add a real CI pipeline (graycore `check-extension` against Mage-OS), and resolve the five open GitHub issues.
+
+## Context
+
+At time of writing:
+
+- Repo version: `3.2.6`. `composer.json` requires `phpunit/phpunit: ^9.5|^10.0` with no PHP constraint. README claims PHP 7.4+.
+- No CI is wired up on GitHub. A `build/tools/composer.json` with Robo + PHPMD + PHPCPD + PDepend + PHPMetrics + `sensiolabs/security-checker` is leftover from the GitLab-CI era — not referenced anywhere in the repo and last touched by "cleanup build" commits.
+- Two open Dependabot alerts: one on `phpunit/phpunit <= 12.5.21` (HIGH, argument injection via newline in INI values), one on `symfony/process < 5.4.51` in `build/tools/composer.lock` (MEDIUM, Windows MSYS2 arg escaping — the main `composer.json` already declares `conflict: symfony/process <5.4.46` so runtime is unaffected).
+- Five open issues: #24, #25, #26, #29, #32. Issue #24's four metrics are already implemented; the issue is simply stale.
+
+## Sequencing
+
+The six PRs below land in order. Each is green (CI passing) before the next opens, so every change is bisectable.
+
+### PR 1 — `chore: bump phpunit, require PHP 8.2, drop dead build/tools`
+
+Closes Dependabot #2 and #3. Single unified PR because the phpunit bump, the PHP constraint, and the `build/tools/` removal together form the baseline every subsequent PR assumes.
+
+**Changes:**
+
+- Delete `build/tools/` (closes #2 — the vulnerable `symfony/process` only exists in that unused lock file).
+- `composer.json`:
+  - `require-dev.phpunit/phpunit`: `^9.5|^10.0` → `^12.5.22 || ^13.1.6`.
+  - Add `require.php`: `^8.2`.
+- Migrate the 27 unit test files and 2 integration test files to phpunit 12+ syntax:
+  - Replace `@dataProvider`, `@test`, `@group`, `@covers` annotations with `#[DataProvider(...)]`, `#[Test]`, `#[Group(...)]`, `#[CoversClass(...)]` attributes.
+  - Data provider methods return `iterable`/`array` explicitly typed.
+  - `setUp(): void` (already the case in the files sampled).
+  - Remove `MockObject` aliases that phpunit 12 dropped if used.
+- `.php-cs-fixer.php`: no change needed; rules are PHP 8.2-compatible.
+- `phpstan.neon`: no change; level 5 stays.
+- `README.md`: update "PHP 7.4 or higher" to "PHP 8.2 or higher".
+
+**Acceptance:**
+
+- `vendor/bin/phpunit Test/Unit` green on PHP 8.2, 8.3, 8.4.
+- `composer install` succeeds without `build/tools/`.
+- `gh api .../dependabot/alerts` returns zero open alerts.
+
+### PR 2 — `ci: add graycore check-extension workflow`
+
+The CI baseline. No new code — just `.github/workflows/ci.yml`. Whatever breaks in the four jobs gets fixed in this same PR; we do not ship a workflow that starts life red.
+
+**Workflow:**
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.supported-version.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: graycoreio/github-actions-magento2/supported-version@main
+        id: supported-version
+        with:
+          kind: supported          # non-EOL only; today == Mage-OS 2.4.8-p4
+          project: mage-os
+
+  check-extension:
+    needs: compute_matrix
+    uses: graycoreio/github-actions-magento2/.github/workflows/check-extension.yaml@main
+    with:
+      matrix: ${{ needs.compute_matrix.outputs.matrix }}
+      fail-fast: false
+    # No secrets block — default magento_repository is https://mirror.mage-os.org/,
+    # which needs no auth.
+```
+
+**What the four jobs do:**
+
+- `unit-test-extension` — installs Mage-OS, composer-requires this module, runs `Test/Unit/` via Magento's vendored phpunit. Independent of our `require-dev` phpunit.
+- `compile-extension` — installs Mage-OS, enables all modules, runs `bin/magento setup:di:compile`. Catches broken DI/type definitions.
+- `coding-standard` — installs `magento/magento-coding-standard` + `magento/php-compatibility-fork`, runs `vendor/bin/phpcs . --standard=Magento2`. Expected to surface violations on first run. All violations get fixed in this PR (not deferred).
+- `integration_test` — provisions MySQL/OpenSearch/RabbitMQ services, installs Mage-OS, composer-requires our module, runs `Test/Integration/` via the Magento integration test framework.
+
+**Likely fix work inside this PR:**
+
+- Magento PHPCS violations in `src/` and `lib/` (`Magento2.Annotation.*`, `Magento2.Functions.DiscouragedFunction`, missing PHPDoc, etc.).
+- Potentially a DI compile failure if any DTO lacks proper constructor arg types under PHP 8.4.
+- Integration tests may need updates for the current Magento framework (e.g., `Magento\TestFramework\Helper\Bootstrap` API has been stable, but the `install-config-mysql.php` under `build/tests/integration/` is unused when graycore's workflow drives installation).
+
+**Acceptance:** All four jobs green on the single-row Mage-OS matrix.
+
+### PR 3 — `chore: close #24 as already implemented`
+
+No code change. Adds a comment on issue #24 citing the four aggregators that satisfy it:
+
+- `magento_shipments_count_total` — `src/Aggregator/Shipment/ShipmentCountAggregator.php` (label: `store_code`, `source`)
+- `magento_catalog_category_count_total` — `src/Aggregator/Category/CategoryCountAggregator.php` (label: `store_code`, `status`, `menu_status`)
+- `magento_website_count_total` — `src/Aggregator/Store/WebsiteCountAggregator.php` (label: none — `store_code` is meaningless on a website-count metric)
+- `magento_store_count_total` — `src/Aggregator/Store/StoreCountAggregator.php` (label: `status` — `store_code` is meaningless, every row would be count=1)
+
+Closes #24. No branch needed; just the comment + close action.
+
+### PR 4 — `feat(#25): magento_complex_product_variations_above_recommended_level`
+
+New aggregator that counts configurable products whose child-product count exceeds Magento's 50-variation recommendation.
+
+**Design:**
+
+- Class: `src/Aggregator/Product/ConfigurableProductVariationsAboveRecommendedLevelAggregator.php`.
+- Pattern: mirrors the existing `AttributeOptionsAboveRecommendedLevelAggregator` in `src/Aggregator/Eav/`.
+- Metric name: `magento_complex_product_variations_above_recommended_level` (matches the issue wording — no `_total` suffix to match the existing `_above_recommended_level_total` aggregator's naming).
+- Type: `gauge`.
+- Labels: none. Single scalar count.
+- Threshold: hardcoded constant `VARIATIONS_THRESHOLD = 50`. YAGNI on admin-configurable until someone asks.
+- Query: SQL against `catalog_product_super_link` grouped by `parent_id`, counting groups with >50 rows.
+- Wiring: new `<item>` in `src/etc/di.xml` under `MetricAggregatorPool`, alphabetically next to `ProductCountAggregator`.
+- Test: `Test/Unit/Aggregator/Product/ConfigurableProductVariationsAboveRecommendedLevelAggregatorTest.php` — mocks `ResourceConnection` and asserts `UpdateMetricService::update` is called with the expected count.
+
+**Acceptance:** New metric appears at `/metrics` with the correct count on a store with >50-variation configurables. CI green.
+
+### PR 5 — `feat(#32): magento_quotes_over_item_limit_count_total`
+
+Counts active quotes (carts) whose item count exceeds Magento's 100-item recommendation.
+
+**Design:**
+
+- Class: `src/Aggregator/Quote/QuotesOverItemLimitCountAggregator.php` (new `Quote/` folder).
+- Metric name: `magento_quotes_over_item_limit_count_total`.
+- Type: `gauge`.
+- Labels: `store_code`.
+- Threshold: hardcoded constant `ITEM_LIMIT = 100`.
+- Query: `SELECT s.code, COUNT(*) FROM quote q JOIN store s ON s.store_id = q.store_id WHERE q.items_count > 100 AND q.is_active = 1 GROUP BY s.code`.
+- Wiring: new `<item>` in `src/etc/di.xml`.
+- Composer: adds `magento/module-quote` to `require`.
+- Test: `Test/Unit/Aggregator/Quote/QuotesOverItemLimitCountAggregatorTest.php`.
+
+**Acceptance:** New metric appears at `/metrics`. CI green.
+
+### PR 6 — `feat(#29, #26): cache flush counter + bad-reviews gauge`
+
+Two small metrics, bundled because neither is big enough for its own PR and both touch docs/DI/tests in the same shape.
+
+**#29 — `magento_cache_flush_count_total`**
+
+- Type: `counter` (first counter metric that is event-driven instead of cron-aggregated).
+- Label: `cache_type` (e.g., `config`, `layout`, `block_html`, `full_page`, ...).
+- Source: `Magento\Framework\Event\ObserverInterface` implementation observing the `clean_cache_by_tags` event.
+- New class: `src/Observer/IncrementCacheFlushCounterObserver.php`.
+- Wiring: new event binding in `src/etc/events.xml` (new file).
+- New service method: `UpdateMetricService::increment(string $code, array $labels): void` that does `metric_value = metric_value + 1` on the existing row (or inserts with value 1). This is the first counter-increment pattern in the module, so the service gets a small API addition rather than overloading `update()`.
+- Aggregator registration: a no-op `CacheFlushCountAggregator` registered in the pool purely so the metric is listed in admin config (so admins can enable/disable it) and appears in `run_as_root:metrics:show`. Its `aggregate()` returns `true` without doing work — the observer does the writes.
+- Test: observer unit test asserting `UpdateMetricService::increment` is called with the right labels for a given event.
+
+**#26 — `magento_products_with_bad_reviews_count_total`**
+
+- Type: `gauge`.
+- Labels: `store_code`.
+- Definition: a product is "bad" when its most recent `rating_summary < 60` (Magento stores rating_summary 0-100; <60 ≈ below 3 of 5 stars).
+- Source: SQL join `review_entity_summary` ← → `store`, aggregated per `store_id`, filtered by `entity_type = 1` (product) and `rating_summary < 60`.
+- New class: `src/Aggregator/Review/ProductsWithBadReviewsCountAggregator.php`.
+- Composer: adds `magento/module-review` to `require`.
+- Guard: aggregator uses `Magento\Framework\Module\Manager::isEnabled('Magento_Review')`; if disabled, returns `true` without writing. This matches the pattern used elsewhere for optional Magento modules.
+- Test: unit test mocking `ResourceConnection` and `Manager::isEnabled`.
+
+**Acceptance:** Both metrics appear at `/metrics`. Cache-flush counter increments on `bin/magento cache:flush`. CI green.
+
+## Out of scope
+
+- Replacing `php-cs-fixer` with `magento/magento-coding-standard` as the canonical style tool. The CI `coding-standard` job enforces Magento PHPCS on top of existing php-cs-fixer rules; deciding whether to keep both or drop one is a follow-up.
+- Widening the CI matrix to include EOL Mage-OS or Adobe Commerce releases. Requires credentials or sacrificing "no secrets needed" promise.
+- Admin-configurable thresholds for any of the new metrics.
+- New Relic pipeline changes — the parallel `SendNewRelicMetricsCron` is left alone.
+
+## Rollback
+
+Each PR is a single feature-flag-free commit on master. Rollback is `git revert` per PR. The six PRs have no inter-dependencies beyond the PHP 8.2 constraint landing in PR 1; reverting PR 1 would require reverting everything.
+
+## Follow-ups to file as issues after landing
+
+- PHPCS-vs-php-cs-fixer consolidation decision (choose one).
+- Widen CI matrix to a few recent EOL releases if users on 2.4.7 report issues.
+- Admin-configurable thresholds for #25 (variations >50) and #32 (items >100) if anyone requests them.

--- a/docs/plans/2026-04-19-pr1-phpunit-php82.md
+++ b/docs/plans/2026-04-19-pr1-phpunit-php82.md
@@ -1,0 +1,401 @@
+# PR 1: phpunit bump + PHP 8.2 requirement + build/tools cleanup — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close Dependabot alerts #2 and #3 by (a) bumping `phpunit/phpunit` to a patched version, (b) adding a `php: ^8.2` constraint, and (c) deleting the unused `build/tools/` directory.
+
+**Architecture:** Pure maintenance PR. No runtime code changes. Three commits on a feature branch: composer bump + test verification, `build/tools/` deletion, docs update. Establishes the baseline every subsequent PR (graycore CI + metric features) depends on.
+
+**Tech Stack:** PHP 8.2+, Composer 2.x, phpunit 12/13. No new tooling.
+
+**Sibling design doc:** `docs/plans/2026-04-19-maintenance-plan-design.md` (covers the full six-PR sequence this plan is step 1 of).
+
+---
+
+## Pre-flight context an executor needs
+
+- **Repo is a Magento 2 module, not a Magento install.** There is no `bin/magento` here. See `CLAUDE.md` at the repo root for the full layout.
+- **Our `require-dev` phpunit is only used for local `vendor/bin/phpunit Test/Unit` runs.** The graycore CI (landing in PR 2) uses Magento's vendored phpunit for CI, not ours.
+- **`build/tools/` is dead code from the GitLab-CI era.** `grep -r 'build/tools' .` outside of `CLAUDE.md` returns no hits. Its `composer.lock` is the source of Dependabot alert #2.
+- **Existing tests are already PHPUnit-modern:** no `@dataProvider`, `@test`, `@group`, or `@covers` annotations. `setUp(): void`. `final class`. `createMock(...)` / `->expects($this->once())`. No `MockBuilder::getMockForAbstractClass()`. Migration surface is therefore almost zero.
+- **The `CLAUDE.md` in the working tree is currently untracked** (created in a prior session) and references `build/tools/`. Both the commit-and-fix are part of this PR.
+- **Branch to use:** current branch `docs/2026-04-maintenance-plan` holds the design doc. Cut a new branch `chore/pr1-phpunit-php82` off `master` for this PR so the design-doc branch can merge independently if desired.
+
+---
+
+## Task 1: Cut the feature branch and stage CLAUDE.md
+
+**Files:**
+- Untracked: `CLAUDE.md` (will be committed in Task 4, not yet)
+
+**Step 1: Confirm clean state from master**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter checkout master
+git -C /Users/david/Herd/magento2-prometheus-exporter status
+```
+Expected: `On branch master ... Untracked files: CLAUDE.md` (CLAUDE.md carries over from the working tree).
+
+**Step 2: Cut the new branch**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter checkout -b chore/pr1-phpunit-php82
+```
+Expected: `Switched to a new branch 'chore/pr1-phpunit-php82'`.
+
+**Step 3: No commit yet.** CLAUDE.md stays untracked until Task 4.
+
+---
+
+## Task 2: Bump composer.json
+
+**Files:**
+- Modify: `composer.json`
+
+**Step 1: Read current state**
+
+Open `composer.json` and note these three lines that will change:
+- `"require": { ... no "php" key today ... }`
+- `"require-dev": { "phpunit/phpunit": "^9.5|^10.0" }`
+
+**Step 2: Apply the edit**
+
+In `composer.json`:
+
+- Add `"php": "^8.2"` as the **first** key of `"require"`. Magento convention: PHP constraint first.
+- Change `"phpunit/phpunit": "^9.5|^10.0"` to `"phpunit/phpunit": "^12.5.22 || ^13.1.6"`.
+
+Resulting `"require"` (partial):
+```json
+"require": {
+  "php": "^8.2",
+  "magento/framework": "*",
+  ...
+}
+```
+
+Resulting `"require-dev"`:
+```json
+"require-dev": {
+  "phpunit/phpunit": "^12.5.22 || ^13.1.6"
+}
+```
+
+**Step 3: Validate composer.json syntax**
+
+Run:
+```bash
+composer validate --no-check-all --strict composer.json
+```
+Expected: `./composer.json is valid`.
+
+---
+
+## Task 3: Install new phpunit, record any deprecation output
+
+**Files:** none modified directly; produces `composer.lock`.
+
+**Step 1: Update the phpunit dependency**
+
+Run:
+```bash
+composer update phpunit/phpunit --with-dependencies
+```
+Expected: phpunit resolved to `12.5.22` or `13.1.x`. Note in the terminal output whether phpunit 12 or 13 was selected — affects attribute imports if we need any in the future (we don't, in this PR).
+
+**Step 2: Verify phpunit version**
+
+Run:
+```bash
+vendor/bin/phpunit --version
+```
+Expected: `PHPUnit 12.5.22 by Sebastian Bergmann and contributors.` (or `13.1.x`).
+
+---
+
+## Task 4: Run the unit test suite against new phpunit
+
+**Files:** none. Diagnostic only.
+
+**Step 1: Run unit tests**
+
+Run:
+```bash
+vendor/bin/phpunit Test/Unit
+```
+Expected (based on pre-flight scan): **all 27 unit-test files pass on the first attempt**. The tests don't use any phpunit 10-only API.
+
+**Step 2: If anything fails, triage**
+
+If there are failures:
+- Deprecation notice about `willReturnSelf` / `returnValue` → rewrite to `willReturn($same)`.
+- "Data provider must return iterable" → we have no data providers; ignore.
+- "Method MockBuilder::getMockForAbstractClass does not exist" → we don't call it; ignore.
+- Anything else: STOP and report. Don't silently mutate test logic to make it pass.
+
+**Step 3: If all green, no commit yet.** Composer changes get committed with test-run evidence in Task 5.
+
+---
+
+## Task 5: Commit the phpunit / PHP bump
+
+**Files:**
+- Staged: `composer.json` only (`composer.lock` is gitignored in this repo — see `.gitignore:45`).
+
+**Step 1: Confirm composer.lock will not be committed**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter check-ignore -v composer.lock
+```
+Expected: `.gitignore:45:composer.lock    composer.lock`. This confirms the file is ignored. Do NOT use `git add -f` to force-add it — module convention here is to let consumers resolve their own lock.
+
+**Step 2: Stage and commit just the manifest change**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter add composer.json
+git -C /Users/david/Herd/magento2-prometheus-exporter commit -m "$(cat <<'EOF'
+chore: require PHP 8.2 and bump phpunit to 12.5.22/13.1.6
+
+Closes GHSA-qrr6-mg7r-m243 (phpunit argument injection via newline in
+INI values). Patched in phpunit 12.5.22 / 13.1.6; no patch in 9.x or
+10.x, so the bump is mandatory.
+
+PHP 8.2 constraint aligns with the Mage-OS 2.4.8+ matrix graycore CI
+will test against.
+EOF
+)"
+```
+Expected: clean commit with 1 file changed. No hook failures (this repo has no pre-commit hooks).
+
+---
+
+## Task 6: Delete build/tools/
+
+**Files:**
+- Delete: `build/tools/composer.json`, `build/tools/composer.lock` (the only files in that directory)
+
+**Step 1: Confirm nothing references build/tools outside of CLAUDE.md**
+
+Run:
+```bash
+grep -r 'build/tools' /Users/david/Herd/magento2-prometheus-exporter \
+  --exclude-dir=.git --exclude-dir=vendor --exclude-dir=build
+```
+Expected: zero matches. (The `--exclude-dir=build` keeps the directory itself from matching.)
+
+Run also:
+```bash
+grep -rn 'build/tools' /Users/david/Herd/magento2-prometheus-exporter/CLAUDE.md
+```
+Expected: one match — the line "`build/` is for CI tooling only: `build/tools/composer.json` pins dev tools...". That line gets rewritten in Task 8.
+
+**Step 2: Remove the directory**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter rm -r build/tools
+```
+Expected: two files staged for deletion. The `build/tests/` sibling and `build/.gitignore` remain untouched.
+
+**Step 3: Verify build/ still exists with the right contents**
+
+Run:
+```bash
+ls /Users/david/Herd/magento2-prometheus-exporter/build
+```
+Expected: `.gitignore  tests`. The `tools` directory is gone; `tests` (integration install config) stays.
+
+**Step 4: Commit**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter commit -m "$(cat <<'EOF'
+chore: delete unused build/tools directory
+
+The directory contained an independent composer project for Robo +
+PHPMD + PHPCPD + PDepend + PHPMetrics + sensiolabs/security-checker,
+leftover from the pre-GitHub GitLab-CI era. It is referenced nowhere
+in the repo and last touched by "cleanup build" commits in 2020.
+
+Closes GHSA-r39x-jcww-82v6 (symfony/process MSYS2 arg escaping) whose
+only surface in this repo was build/tools/composer.lock.
+EOF
+)"
+```
+
+---
+
+## Task 7: Update README.md PHP version
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Find the line**
+
+Open `README.md` and locate (around line 35):
+```
+- PHP 7.4 or higher
+```
+
+**Step 2: Replace**
+
+Change to:
+```
+- PHP 8.2 or higher
+```
+
+**Step 3: Stage but don't commit yet.** Bundled with the CLAUDE.md fix in Task 8.
+
+---
+
+## Task 8: Fix CLAUDE.md and commit docs
+
+**Files:**
+- Modify: `CLAUDE.md` (currently untracked — this is the first commit that adds it)
+
+**Step 1: Locate the stale line**
+
+Open `CLAUDE.md` and find the paragraph starting `build/` is for CI tooling only (under the "Layout and autoload" section). The surrounding text reads:
+
+> `build/` is for CI tooling only: `build/tools/composer.json` pins dev tools (robo, phpmd, phpcpd, phpmetrics, pdepend) and `build/tests/integration/install-config-mysql.php` is the Magento integration-test install config. Ignore `build/` for feature work.
+
+**Step 2: Rewrite that sentence to match post-deletion reality**
+
+Replace it with:
+
+> `build/tests/integration/install-config-mysql.php` is the Magento integration-test install config used by `Test/Integration/`. That's the only reason `build/` still exists.
+
+**Step 3: Stage and commit README + CLAUDE.md together**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter add README.md CLAUDE.md
+git -C /Users/david/Herd/magento2-prometheus-exporter commit -m "$(cat <<'EOF'
+docs: update README PHP requirement and land CLAUDE.md
+
+README: PHP 7.4 -> 8.2 to match the new composer constraint.
+
+CLAUDE.md: initial commit of the Claude Code guidance file, with the
+reference to the now-deleted build/tools directory corrected.
+EOF
+)"
+```
+
+---
+
+## Task 9: Full verification
+
+**Files:** none modified.
+
+**Step 1: Composer sanity**
+
+Run:
+```bash
+composer validate --strict
+composer install --dry-run
+```
+Expected: both succeed with no errors.
+
+**Step 2: Tests**
+
+Run:
+```bash
+vendor/bin/phpunit Test/Unit
+```
+Expected: all 27 unit test files pass, no deprecation warnings, no errors.
+
+**Step 3: Static analysis**
+
+Run:
+```bash
+vendor/bin/phpstan analyse
+```
+Expected: phpstan passes at level 5, same as before (the only code changes were in composer.json, which phpstan doesn't analyse). If phpstan is missing from `vendor/bin`, it was never a declared dev dep — noted for a follow-up, not a blocker here.
+
+**Step 4: Style**
+
+Run:
+```bash
+vendor/bin/php-cs-fixer fix --dry-run --diff
+```
+Expected: no diff output (no PHP files were touched).
+
+**Step 5: Final git state**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter log --oneline master..HEAD
+```
+Expected three commits:
+```
+<sha>  docs: update README PHP requirement and land CLAUDE.md
+<sha>  chore: delete unused build/tools directory
+<sha>  chore: require PHP 8.2 and bump phpunit to 12.5.22/13.1.6
+```
+
+---
+
+## Task 10: Push and open PR
+
+**Step 1: Push branch**
+
+Run:
+```bash
+git -C /Users/david/Herd/magento2-prometheus-exporter push -u origin chore/pr1-phpunit-php82
+```
+
+**Step 2: Open PR**
+
+Run:
+```bash
+gh pr create \
+  --repo run-as-root/magento2-prometheus-exporter \
+  --base master \
+  --title "chore: bump phpunit, require PHP 8.2, drop dead build/tools" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Bumps `phpunit/phpunit` to `^12.5.22 || ^13.1.6` to close Dependabot alert #3 (GHSA-qrr6-mg7r-m243, argument injection via newline in INI values).
+- Adds `php: ^8.2` to `composer.json`. Aligns with the Mage-OS 2.4.8 matrix that graycore CI will test against in the follow-up PR.
+- Deletes `build/tools/`, leftover from the GitLab-CI era and referenced nowhere. Closes Dependabot alert #2 (GHSA-r39x-jcww-82v6, symfony/process on Windows MSYS2), whose only surface was `build/tools/composer.lock`.
+- Updates README PHP version. Adds CLAUDE.md (initial commit, with the stale build/tools reference corrected).
+
+No runtime code changes. All 27 unit tests pass on the new phpunit without modification.
+
+## Test plan
+
+- [x] `composer validate --strict` passes
+- [x] `vendor/bin/phpunit Test/Unit` green on PHP 8.2
+- [x] `vendor/bin/phpstan analyse` green
+- [x] `vendor/bin/php-cs-fixer fix --dry-run` reports no changes
+
+## Context
+
+First of a six-PR sequence documented in `docs/plans/2026-04-19-maintenance-plan-design.md`.
+EOF
+)"
+```
+Expected: PR URL printed. Return it to the user.
+
+---
+
+## Out of scope for this PR
+
+- Any `.github/workflows` files — that's PR 2.
+- Any new metric code — PRs 4-6.
+- Replacing `php-cs-fixer` with `magento/magento-coding-standard` — deliberate follow-up decision after CI reveals the PHPCS diff.
+- Closing issue #24 — PR 3.
+- Widening the matrix to EOL Mage-OS — out of scope per the design doc.
+
+## Known risks and mitigations
+
+- **Risk:** phpunit 12/13 introduces a deprecation or breakage not caught by the pre-flight annotation scan.
+  **Mitigation:** Task 4 runs the full suite before anything is committed; Task 5 only commits after a green run. If anything fails, Task 4 Step 2 says STOP, don't mutate test logic — we'd need to pause the plan and re-brainstorm.
+- **Risk:** `composer install` in a consumer Magento store breaks because Magento's own `require` wants PHP `^8.1` on older Mage-OS.
+  **Mitigation:** out of scope — this module's declared PHP `^8.2` correctly represents what the test matrix covers. Consumers on older PHP were already pinned to the prior module release (`3.2.6`). The next release will be a major bump; semver is on our side.
+- **Risk:** consumers still on PHP 8.1 can't upgrade.
+  **Mitigation:** this is a feature, not a bug — if we allowed 8.1, CI couldn't guarantee it works, and the phpunit bump requires 8.2 anyway. Tag the next release as a major version bump. Consumers on 8.1 stay on `3.x`.


### PR DESCRIPTION
## Summary

Lands two internal planning documents that subsequent PRs reference:

- `docs/plans/2026-04-19-maintenance-plan-design.md` — six-PR sequence covering the two Dependabot alerts and five open issues (#24, #25, #26, #29, #32). Design-level decisions and sequencing.
- `docs/plans/2026-04-19-pr1-phpunit-php82.md` — bite-sized implementation plan for the first PR (originally scoped to also bump phpunit + migrate tests, see note below).

## Scope note on the PR 1 sub-plan

The PR 1 sub-plan was written before we discovered the existing test suite uses several phpunit APIs removed in 10/11/12 (`withConsecutive`, `at`, `getMockForAbstractClass`) and that a handful of tests are already broken on master for unrelated reasons. Rather than bundle a large test-migration effort into PR 1, scope was narrowed to the X1 variant (PHP 8.2 requirement + `build/tools/` deletion + docs), shipped in #58. A phpunit bump + test migration remains a candidate for a later, separate PR. The design doc's PR 1 row should be read as "original intent"; #58 is what actually shipped.

No code changes. Docs-only PR.

## Test plan

- [x] Files render as Markdown
- [x] Design doc reference from #58 will resolve once this merges into master

## Context

Paired with #58. Intended to merge before or alongside it so that #58's body reference to `docs/plans/2026-04-19-maintenance-plan-design.md (on branch docs/2026-04-maintenance-plan)` points to a file that exists on master.