### PR TITLE
feat: add complex product variations metric (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ scrape_configs:
 |--------|------|--------|-------------|
 | `magento_products_by_type_count_total` | gauge | `product_type` | Count of products by type (simple, configurable, etc.) |
 | `magento_catalog_category_count_total` | gauge | `status`, `menu_status`, `store_code` | Count of categories by status |
+| `magento_complex_product_variations_above_recommended_level` | gauge | - | Count of configurable products with more than 50 variations (performance risk) |
 
 ### EAV & Attribute Metrics
 | Metric | Type | Labels | Description |

--- a/Test/Unit/Aggregator/Product/ComplexProductVariationsAboveRecommendedLevelAggregatorTest.php
+++ b/Test/Unit/Aggregator/Product/ComplexProductVariationsAboveRecommendedLevelAggregatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Product;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Product\ComplexProductVariationsAboveRecommendedLevelAggregator;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
+
+final class ComplexProductVariationsAboveRecommendedLevelAggregatorTest extends TestCase
+{
+    private ComplexProductVariationsAboveRecommendedLevelAggregator $sut;
+
+    /** @var MockObject|UpdateMetricServiceInterface */
+    private $updateMetricService;
+
+    /** @var MockObject|ResourceConnection */
+    private $resourceConnection;
+
+    protected function setUp(): void
+    {
+        $this->updateMetricService = $this->createMock(UpdateMetricServiceInterface::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+
+        $this->sut = new ComplexProductVariationsAboveRecommendedLevelAggregator(
+            $this->updateMetricService,
+            $this->resourceConnection
+        );
+    }
+
+    public function testMetadata(): void
+    {
+        self::assertSame('magento_complex_product_variations_above_recommended_level', $this->sut->getCode());
+        self::assertSame('gauge', $this->sut->getType());
+        self::assertStringContainsString('more than 50 variations', $this->sut->getHelp());
+    }
+
+    public function testAggregate(): void
+    {
+        $adapter = $this->createMock(AdapterInterface::class);
+
+        $this->resourceConnection
+            ->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($adapter);
+
+        $adapter->method('getTableName')->willReturnArgument(0);
+
+        $adapter
+            ->expects($this->once())
+            ->method('fetchOne')
+            ->with(
+                $this->stringContains('catalog_product_super_link'),
+                [50]
+            )
+            ->willReturn('7');
+
+        $this->updateMetricService
+            ->expects($this->once())
+            ->method('update')
+            ->with('magento_complex_product_variations_above_recommended_level', '7')
+            ->willReturn(true);
+
+        $result = $this->sut->aggregate();
+
+        self::assertTrue($result);
+    }
+}

--- a/src/Aggregator/Product/ComplexProductVariationsAboveRecommendedLevelAggregator.php
+++ b/src/Aggregator/Product/ComplexProductVariationsAboveRecommendedLevelAggregator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Aggregator\Product;
+
+use Magento\Framework\App\ResourceConnection;
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
+
+class ComplexProductVariationsAboveRecommendedLevelAggregator implements MetricAggregatorInterface
+{
+    private const METRIC_CODE = 'magento_complex_product_variations_above_recommended_level';
+    private const RECOMMENDED_VARIATION_LIMIT = 50;
+
+    private UpdateMetricServiceInterface $updateMetricService;
+    private ResourceConnection $connection;
+
+    public function __construct(
+        UpdateMetricServiceInterface $updateMetricService,
+        ResourceConnection $connection
+    ) {
+        $this->updateMetricService = $updateMetricService;
+        $this->connection = $connection;
+    }
+
+    public function getCode(): string
+    {
+        return self::METRIC_CODE;
+    }
+
+    public function getHelp(): string
+    {
+        return 'Number of configurable products with more than 50 variations (above recommended level)';
+    }
+
+    public function getType(): string
+    {
+        return 'gauge';
+    }
+
+    public function aggregate(): bool
+    {
+        $connection = $this->connection->getConnection();
+
+        $sql = "
+            SELECT COUNT(*) as count
+            FROM (
+                SELECT parent_id
+                FROM {$connection->getTableName('catalog_product_super_link')}
+                GROUP BY parent_id
+                HAVING COUNT(product_id) > ?
+            ) as configurables_above_limit
+        ";
+
+        $result = $connection->fetchOne($sql, [self::RECOMMENDED_VARIATION_LIMIT]);
+        $configurablesAboveLimit = (int) $result;
+
+        return $this->updateMetricService->update(
+            $this->getCode(),
+            (string) $configurablesAboveLimit
+        );
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -51,6 +51,7 @@
                 <!-- Product Aggregator -->
                 <item name="ProductCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Product\ProductCountAggregator</item>
                 <item name="ProductByTypeCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Product\ProductByTypeCountAggregator</item>
+                <item name="ComplexProductVariationsAboveRecommendedLevelAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Product\ComplexProductVariationsAboveRecommendedLevelAggregator</item>
 
                 <!-- Shipping Aggregator -->
                 <item name="ActiveShippingMethodsCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Shipping\ActiveShippingMethodsCountAggregator</item>


### PR DESCRIPTION
## Summary

Adds the `magento_complex_product_variations_above_recommended_level` gauge: count of configurable products whose child count exceeds Magento's recommended 50-variation limit. Closes #25.

## Design

Mirrors the existing `AttributeOptionsAboveRecommendedLevelAggregator` pattern:
- Single SQL query against `catalog_product_super_link` grouped by `parent_id` with `HAVING COUNT(product_id) > 50`.
- Gauge, no labels, threshold hardcoded as a class constant (YAGNI on admin-configurable until someone asks).
- Registered in `src/etc/di.xml` under `MetricAggregatorPool`.
- Unit test covers metadata accessors and the aggregate path via mocked `AdapterInterface`.

## Test plan

- [x] CI (unit / compile / coding-standard / integration against 2.4.6 / 2.4.7 / 2.4.8)

## Context

Fourth PR in the six-PR sequence documented in `docs/plans/2026-04-19-maintenance-plan-design.md`. Plan is to stack #25 / #32 / #29 / #26 on master, merge the full series, then cut a major version release.