### PR TITLE
feat: add cart-item-limit metric (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ scrape_configs:
 | `magento_store_count_total` | gauge | `status` | Count of stores by status |
 | `magento_website_count_total` | gauge | - | Total count of websites |
 | `magento_shipments_count_total` | counter | `source`, `store_code` | Count of shipments created |
+| `magento_quotes_over_item_limit_count_total` | gauge | `store_code` | Count of active carts with more than 100 items (performance risk) |
 
 ## 🔐 Security
 

--- a/Test/Unit/Aggregator/Quote/QuotesOverItemLimitCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Quote/QuotesOverItemLimitCountAggregatorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Quote;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Quote\QuotesOverItemLimitCountAggregator;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
+
+final class QuotesOverItemLimitCountAggregatorTest extends TestCase
+{
+    private QuotesOverItemLimitCountAggregator $sut;
+
+    /** @var MockObject|UpdateMetricServiceInterface */
+    private $updateMetricService;
+
+    /** @var MockObject|ResourceConnection */
+    private $resourceConnection;
+
+    protected function setUp(): void
+    {
+        $this->updateMetricService = $this->createMock(UpdateMetricServiceInterface::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+
+        $this->sut = new QuotesOverItemLimitCountAggregator(
+            $this->updateMetricService,
+            $this->resourceConnection
+        );
+    }
+
+    public function testMetadata(): void
+    {
+        self::assertSame('magento_quotes_over_item_limit_count_total', $this->sut->getCode());
+        self::assertSame('gauge', $this->sut->getType());
+        self::assertStringContainsString('more than 100', $this->sut->getHelp());
+    }
+
+    public function testAggregateEmitsOneMetricPerStore(): void
+    {
+        $adapter = $this->createMock(AdapterInterface::class);
+        $select = $this->createMock(Select::class);
+
+        $this->resourceConnection
+            ->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($adapter);
+
+        $adapter->method('getTableName')->willReturnArgument(0);
+        $adapter->method('select')->willReturn($select);
+        $select->method('from')->willReturnSelf();
+        $select->method('joinInner')->willReturnSelf();
+        $select->method('where')->willReturnSelf();
+        $select->method('reset')->willReturnSelf();
+        $select->method('columns')->willReturnSelf();
+        $select->method('group')->willReturnSelf();
+
+        $adapter
+            ->expects($this->once())
+            ->method('fetchAll')
+            ->with($select)
+            ->willReturn([
+                ['STORE_CODE' => 'default', 'QUOTE_COUNT' => '3'],
+                ['STORE_CODE' => 'en', 'QUOTE_COUNT' => '1'],
+            ]);
+
+        $updateCallCount = 0;
+        $this->updateMetricService
+            ->expects($this->exactly(2))
+            ->method('update')
+            ->willReturnCallback(function (...$args) use (&$updateCallCount) {
+                $updateCallCount++;
+                $expected = [
+                    ['magento_quotes_over_item_limit_count_total', '3', ['store_code' => 'default']],
+                    ['magento_quotes_over_item_limit_count_total', '1', ['store_code' => 'en']],
+                ];
+                self::assertEquals($expected[$updateCallCount - 1], array_slice($args, 0, 3));
+
+                return true;
+            });
+
+        self::assertTrue($this->sut->aggregate());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "magento/module-shipping": "*",
     "magento/module-catalog": "*",
     "magento/module-sales": "*",
+    "magento/module-quote": "*",
     "laminas/laminas-http": "^2.15.0",
     "magento/module-config": "*",
     "magento/module-backend": "*",

--- a/src/Aggregator/Quote/QuotesOverItemLimitCountAggregator.php
+++ b/src/Aggregator/Quote/QuotesOverItemLimitCountAggregator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Aggregator\Quote;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
+
+class QuotesOverItemLimitCountAggregator implements MetricAggregatorInterface
+{
+    private const METRIC_CODE = 'magento_quotes_over_item_limit_count_total';
+    private const ITEM_LIMIT = 100;
+
+    private UpdateMetricServiceInterface $updateMetricService;
+    private ResourceConnection $resourceConnection;
+
+    public function __construct(
+        UpdateMetricServiceInterface $updateMetricService,
+        ResourceConnection $resourceConnection
+    ) {
+        $this->updateMetricService = $updateMetricService;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    public function getCode(): string
+    {
+        return self::METRIC_CODE;
+    }
+
+    public function getHelp(): string
+    {
+        return 'Count of active carts with more than 100 items (Magento recommends staying at or below 100).';
+    }
+
+    public function getType(): string
+    {
+        return 'gauge';
+    }
+
+    public function aggregate(): bool
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $rows = $connection->fetchAll($this->buildSelect($connection));
+
+        foreach ($rows as $row) {
+            $count = (int) ($row['QUOTE_COUNT'] ?? 0);
+            $storeCode = (string) ($row['STORE_CODE'] ?? '');
+
+            $this->updateMetricService->update(
+                self::METRIC_CODE,
+                (string) $count,
+                ['store_code' => $storeCode]
+            );
+        }
+
+        return true;
+    }
+
+    private function buildSelect(AdapterInterface $connection): Select
+    {
+        return $connection->select()
+            ->from(['q' => $connection->getTableName('quote')])
+            ->joinInner(
+                ['s' => $connection->getTableName('store')],
+                's.store_id = q.store_id',
+                []
+            )
+            ->where('q.is_active = ?', 1)
+            ->where('q.items_count > ?', self::ITEM_LIMIT)
+            ->reset(Select::COLUMNS)
+            ->columns([
+                'STORE_CODE' => 's.code',
+                'QUOTE_COUNT' => 'COUNT(q.entity_id)',
+            ])
+            ->group('s.code');
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -52,6 +52,9 @@
                 <item name="ProductCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Product\ProductCountAggregator</item>
                 <item name="ProductByTypeCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Product\ProductByTypeCountAggregator</item>
 
+                <!-- Quote Aggregator -->
+                <item name="QuotesOverItemLimitCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Quote\QuotesOverItemLimitCountAggregator</item>
+
                 <!-- Shipping Aggregator -->
                 <item name="ActiveShippingMethodsCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Shipping\ActiveShippingMethodsCountAggregator</item>
 

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -11,6 +11,7 @@
             <module name="Magento_Shipping" />
             <module name="Magento_Catalog" />
             <module name="Magento_Sales" />
+            <module name="Magento_Quote" />
             <module name="Magento_Config" />
             <module name="Magento_Backend" />
         </sequence>


### PR DESCRIPTION
## Summary

Adds `magento_quotes_over_item_limit_count_total` gauge with a `store_code` label: count of active carts per store whose `items_count` exceeds Magento's recommended 100-item limit. Closes #32.

## Design

- Aggregator under new `src/Aggregator/Quote/` folder.
- Single `SELECT s.code, COUNT(q.entity_id) FROM quote q JOIN store s WHERE q.is_active=1 AND q.items_count > 100 GROUP BY s.code`.
- Threshold hardcoded at 100 (YAGNI on admin-configurable).
- `magento/module-quote` added to `composer.json` require and `module.xml` sequence (new runtime dep; previously the module didn't touch quote tables).
- Registered in `src/etc/di.xml` under `MetricAggregatorPool`.
- Unit test covers metadata and the multi-store aggregate path.

## Test plan

- [x] CI (unit / compile / coding-standard / integration against 2.4.6 / 2.4.7 / 2.4.8)

## Context

Fifth PR of the six-PR sequence (`docs/plans/2026-04-19-maintenance-plan-design.md`). Final PR #62 will bundle the cache-flush counter (#29) and bad-reviews gauge (#26).