### PR TITLE
feat: cache flush counter via plugin (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ scrape_configs:
 | `magento_cronjob_count_total` | gauge | `status`, `job_code` | Count of cron jobs by status |
 | `magento_cronjob_broken_count_total` | gauge | - | Count of broken cron jobs |
 | `magento_indexer_backlog_count_total` | gauge | `title` | Count of items in indexer backlog |
+| `magento_cache_flush_count_total` | counter | - | Cumulative count of `bin/magento cache:flush` / admin flush-storage invocations |
 
 ### Infrastructure Metrics
 | Metric | Type | Labels | Description |

--- a/Test/Unit/Aggregator/Cache/CacheFlushCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Cache/CacheFlushCountAggregatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Cache;
+
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Cache\CacheFlushCountAggregator;
+
+final class CacheFlushCountAggregatorTest extends TestCase
+{
+    private CacheFlushCountAggregator $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = new CacheFlushCountAggregator();
+    }
+
+    public function testMetadata(): void
+    {
+        self::assertSame('magento_cache_flush_count_total', $this->sut->getCode());
+        self::assertSame('counter', $this->sut->getType());
+        self::assertStringContainsString('cache flush', $this->sut->getHelp());
+    }
+
+    public function testAggregateIsANoOp(): void
+    {
+        // Value is populated by the ManagerPlugin on each flush() call; the
+        // aggregator exists only so the metric shows up in the pool.
+        self::assertTrue($this->sut->aggregate());
+    }
+}

--- a/Test/Unit/Plugin/Cache/ManagerPluginTest.php
+++ b/Test/Unit/Plugin/Cache/ManagerPluginTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Plugin\Cache;
+
+use Magento\Framework\App\Cache\Manager;
+use Magento\Framework\App\DeploymentConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Plugin\Cache\ManagerPlugin;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
+
+final class ManagerPluginTest extends TestCase
+{
+    /** @var MockObject|UpdateMetricServiceInterface */
+    private $updateMetricService;
+
+    /** @var MockObject|DeploymentConfig */
+    private $deploymentConfig;
+
+    private ManagerPlugin $sut;
+
+    protected function setUp(): void
+    {
+        $this->updateMetricService = $this->createMock(UpdateMetricServiceInterface::class);
+        $this->deploymentConfig = $this->createMock(DeploymentConfig::class);
+        $this->sut = new ManagerPlugin($this->updateMetricService, $this->deploymentConfig);
+    }
+
+    public function testAfterFlushIncrementsCounterWhenMagentoInstalled(): void
+    {
+        $this->deploymentConfig->method('isAvailable')->willReturn(true);
+        $subject = $this->createMock(Manager::class);
+
+        $this->updateMetricService
+            ->expects($this->once())
+            ->method('increment')
+            ->with('magento_cache_flush_count_total')
+            ->willReturn(true);
+
+        self::assertNull($this->sut->afterFlush($subject, null, ['config']));
+    }
+
+    public function testAfterFlushSkipsDuringSetupInstall(): void
+    {
+        $this->deploymentConfig->method('isAvailable')->willReturn(false);
+        $subject = $this->createMock(Manager::class);
+
+        $this->updateMetricService->expects($this->never())->method('increment');
+
+        self::assertNull($this->sut->afterFlush($subject, null, ['config']));
+    }
+
+    public function testAfterFlushSwallowsIncrementExceptions(): void
+    {
+        $this->deploymentConfig->method('isAvailable')->willReturn(true);
+        $subject = $this->createMock(Manager::class);
+
+        $this->updateMetricService
+            ->method('increment')
+            ->willThrowException(new \RuntimeException('db temporarily unavailable'));
+
+        // Must not re-throw.
+        self::assertNull($this->sut->afterFlush($subject, null, ['config']));
+    }
+}

--- a/src/Aggregator/Cache/CacheFlushCountAggregator.php
+++ b/src/Aggregator/Cache/CacheFlushCountAggregator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Aggregator\Cache;
+
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+
+/**
+ * Metadata-only aggregator for the cache-flush counter. The actual value is
+ * incremented by {@see \RunAsRoot\PrometheusExporter\Plugin\Cache\ManagerPlugin}
+ * on every `Magento\Framework\App\Cache\Manager::flush()` call. aggregate()
+ * is a no-op so the cron collector doesn't overwrite the counter each minute.
+ *
+ * The aggregator still needs to be registered in the pool so the metric shows
+ * up in the admin enable/disable list and in the /metrics render.
+ */
+class CacheFlushCountAggregator implements MetricAggregatorInterface
+{
+    public const METRIC_CODE = 'magento_cache_flush_count_total';
+
+    public function getCode(): string
+    {
+        return self::METRIC_CODE;
+    }
+
+    public function getHelp(): string
+    {
+        return 'Cumulative count of cache flush invocations (Magento\Framework\App\Cache\Manager::flush).';
+    }
+
+    public function getType(): string
+    {
+        return 'counter';
+    }
+
+    public function aggregate(): bool
+    {
+        return true;
+    }
+}

--- a/src/Plugin/Cache/ManagerPlugin.php
+++ b/src/Plugin/Cache/ManagerPlugin.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Plugin\Cache;
+
+use Magento\Framework\App\Cache\Manager;
+use Magento\Framework\App\DeploymentConfig;
+use RunAsRoot\PrometheusExporter\Aggregator\Cache\CacheFlushCountAggregator;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
+use Throwable;
+
+class ManagerPlugin
+{
+    private UpdateMetricServiceInterface $updateMetricService;
+    private DeploymentConfig $deploymentConfig;
+
+    public function __construct(
+        UpdateMetricServiceInterface $updateMetricService,
+        DeploymentConfig $deploymentConfig
+    ) {
+        $this->updateMetricService = $updateMetricService;
+        $this->deploymentConfig = $deploymentConfig;
+    }
+
+    /**
+     * @param string[] $typeCodes
+     */
+    public function afterFlush(Manager $subject, $result, array $typeCodes = []): mixed
+    {
+        if (!$this->deploymentConfig->isAvailable()) {
+            return $result;
+        }
+
+        try {
+            $this->updateMetricService->increment(CacheFlushCountAggregator::METRIC_CODE);
+        } catch (Throwable) {
+            // A metric write must never break the host application.
+        }
+
+        return $result;
+    }
+}

--- a/src/Service/UpdateMetricService.php
+++ b/src/Service/UpdateMetricService.php
@@ -50,4 +50,16 @@ class UpdateMetricService implements UpdateMetricServiceInterface
 
         return true;
     }
+
+    public function increment(string $code, array $labels = []): bool
+    {
+        try {
+            $metric = $this->metricRepository->getByCodeAndLabels($code, $labels);
+            $next = (int) $metric->getValue() + 1;
+        } catch (NoSuchEntityException) {
+            $next = 1;
+        }
+
+        return $this->update($code, (string) $next, $labels);
+    }
 }

--- a/src/Service/UpdateMetricServiceInterface.php
+++ b/src/Service/UpdateMetricServiceInterface.php
@@ -7,4 +7,6 @@ namespace RunAsRoot\PrometheusExporter\Service;
 interface UpdateMetricServiceInterface
 {
     public function update(string $code, string $value, array $labels = []): bool;
+
+    public function increment(string $code, array $labels = []): bool;
 }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -8,6 +8,9 @@
     <type name="RunAsRoot\PrometheusExporter\Metric\MetricAggregatorPool">
         <arguments>
             <argument name="items" xsi:type="array">
+                <!-- Cache Aggregator -->
+                <item name="CacheFlushCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Cache\CacheFlushCountAggregator</item>
+
                 <!-- Category Aggregator -->
                 <item name="CategoryCountAggregator" xsi:type="object">RunAsRoot\PrometheusExporter\Aggregator\Category\CategoryCountAggregator</item>
 
@@ -118,6 +121,11 @@
         <arguments>
             <argument name="aggregateMetricsCron" xsi:type="object">RunAsRoot\PrometheusExporter\Cron\AggregateMetricsCron\Proxy</argument>
         </arguments>
+    </type>
+
+    <type name="Magento\Framework\App\Cache\Manager">
+        <plugin name="run_as_root_prometheus_cache_flush_counter"
+                type="RunAsRoot\PrometheusExporter\Plugin\Cache\ManagerPlugin"/>
     </type>
 
 </config>


### PR DESCRIPTION
## Summary

Adds **`magento_cache_flush_count_total`** — a counter incremented once per `Magento\Framework\App\Cache\Manager::flush()` invocation. Captures the admin "Flush Cache Storage" button and `bin/magento cache:flush`. Closes #29.

## Why a plugin, not an observer

The original approach in #63 registered an observer on `clean_cache_by_tags` via `events.xml`. That wiring deterministically segfaulted phpunit integration-test bootstrap on the Magento 2.4.6-p14 / PHP 8.2 / MySQL 8.0 matrix row (bisected by removing `events.xml` alone — CI went green). The crash was at C level; `try/catch Throwable` and `DeploymentConfig::isAvailable()` both failed to prevent it.

Plugins are wired via `di.xml` rather than `events.xml` and go through Magento's interceptor codegen rather than the event-manager dispatcher. Different generator, different behaviour. No segfault expected.

## Design

- **`src/Plugin/Cache/ManagerPlugin.php`** — `afterFlush($subject, $result, array $typeCodes): mixed`. Calls `UpdateMetricServiceInterface::increment(CacheFlushCountAggregator::METRIC_CODE)`. Guarded by `DeploymentConfig::isAvailable()` (short-circuits during setup:install) and wrapped in `try/catch Throwable` as a secondary safety net.
- **`src/Aggregator/Cache/CacheFlushCountAggregator.php`** — metadata-only (`aggregate()` returns `true`). Exists so the metric surfaces in the admin enable/disable list and the `/metrics` render.
- **`UpdateMetricServiceInterface::increment(string $code, array $labels = []): bool`** — reads current value, adds 1, writes back through `update()`. If the metric row doesn't exist yet, starts at 1.
- Unit tests cover the plugin (installed / not-installed / exception paths) and the aggregator metadata.

## Test plan

- [x] Unit tests for plugin and aggregator
- [ ] CI across Magento 2.4.6-p14 / 2.4.7-p9 / 2.4.8-p4 (the previous PR's exact failure matrix)

## Context

Follow-up to #63. Once merged, all 5 original issues (#24/#25/#26/#29/#32) are resolved and the major-version release can go out.