### PR TITLE
Add compatibility for Magento 2.4.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches:
+      - '**'
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - '**'
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
@@ -31,15 +31,11 @@ final class CmsBlockCountAggregatorUnitTest extends TestCase
         $updateMetricService = $this->createMock(UpdateMetricService::class);
         $updateMetricService->method('update')->willReturn(true);
 
-        $searchResultInterface = $this->getMockBuilder(BlockSearchResultsInterface::class)
-            ->onlyMethods(['getTotalCount'])
-            ->getMock();
+        $searchResultInterface = $this->getMockBuilder(BlockSearchResultsInterface::class)->getMockForAbstractClass();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 
         /** @var BlockRepositoryInterface | MockObject $cmsRepository */
-        $cmsRepository = $this->getMockBuilder(BlockRepositoryInterface::class)
-            ->onlyMethods(['getList'])
-            ->getMock();
+        $cmsRepository = $this->getMockBuilder(BlockRepositoryInterface::class)->getMockForAbstractClass();
         $cmsRepository->method('getList')->willReturn($searchResultInterface);
 
         /** @var SearchCriteriaBuilder | MockObject $searchCriteriaBuilder */

--- a/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
@@ -32,13 +32,13 @@ final class CmsBlockCountAggregatorUnitTest extends TestCase
         $updateMetricService->method('update')->willReturn(true);
 
         $searchResultInterface = $this->getMockBuilder(BlockSearchResultsInterface::class)
-            ->onlyMethods(['getTotalCount'])
+            ->onlyMethods(['getTotalCount', 'getItems', 'setItems', 'getSearchCriteria', 'setSearchCriteria'])
             ->getMock();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 
         /** @var BlockRepositoryInterface | MockObject $cmsRepository */
         $cmsRepository = $this->getMockBuilder(BlockRepositoryInterface::class)
-            ->onlyMethods(['getList'])
+            ->onlyMethods(['getList', 'save', 'deleteById', 'delete', 'getById'])
             ->getMock();
         $cmsRepository->method('getList')->willReturn($searchResultInterface);
 

--- a/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
@@ -31,11 +31,15 @@ final class CmsBlockCountAggregatorUnitTest extends TestCase
         $updateMetricService = $this->createMock(UpdateMetricService::class);
         $updateMetricService->method('update')->willReturn(true);
 
-        $searchResultInterface = $this->getMockBuilder(BlockSearchResultsInterface::class)->getMockForAbstractClass();
+        $searchResultInterface = $this->getMockBuilder(BlockSearchResultsInterface::class)
+            ->onlyMethods(['getTotalCount'])
+            ->getMock();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 
         /** @var BlockRepositoryInterface | MockObject $cmsRepository */
-        $cmsRepository = $this->getMockBuilder(BlockRepositoryInterface::class)->getMockForAbstractClass();
+        $cmsRepository = $this->getMockBuilder(BlockRepositoryInterface::class)
+            ->onlyMethods(['getList'])
+            ->getMock();
         $cmsRepository->method('getList')->willReturn($searchResultInterface);
 
         /** @var SearchCriteriaBuilder | MockObject $searchCriteriaBuilder */

--- a/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsBlockCountAggregatorUnitTest.php
@@ -32,7 +32,7 @@ final class CmsBlockCountAggregatorUnitTest extends TestCase
         $updateMetricService->method('update')->willReturn(true);
 
         $searchResultInterface = $this->getMockBuilder(BlockSearchResultsInterface::class)
-            ->onlyMethods(['getTotalCount', 'getItems', 'setItems', 'getSearchCriteria', 'setSearchCriteria'])
+            ->onlyMethods(['getTotalCount', 'setTotalCount','getItems', 'setItems', 'getSearchCriteria', 'setSearchCriteria'])
             ->getMock();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 

--- a/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
@@ -31,9 +31,7 @@ final class CmsPageCountAggregatorUnitTest extends TestCase
         $updateMetricService = $this->createMock(UpdateMetricService::class);
         $updateMetricService->expects($this->once())->method('update')->willReturn(true);
 
-        $searchResultInterface = $this->getMockBuilder(PageSearchResultsInterface::class)
-            ->onlyMethods(['getTotalCount'])
-            ->getMock();
+        $searchResultInterface = $this->getMockBuilder(PageSearchResultsInterface::class)->getMockForAbstractClass();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 
         /** @var PageRepositoryInterface | MockObject $cmsRepository */

--- a/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
@@ -32,7 +32,7 @@ final class CmsPageCountAggregatorUnitTest extends TestCase
         $updateMetricService->expects($this->once())->method('update')->willReturn(true);
 
         $searchResultInterface = $this->getMockBuilder(PageSearchResultsInterface::class)
-            ->onlyMethods(['getTotalCount'])
+            ->onlyMethods(['getTotalCount', 'getItems', 'setItems', 'getSearchCriteria', 'setSearchCriteria'])
             ->getMock();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 

--- a/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
@@ -31,7 +31,9 @@ final class CmsPageCountAggregatorUnitTest extends TestCase
         $updateMetricService = $this->createMock(UpdateMetricService::class);
         $updateMetricService->expects($this->once())->method('update')->willReturn(true);
 
-        $searchResultInterface = $this->getMockBuilder(PageSearchResultsInterface::class)->getMockForAbstractClass();
+        $searchResultInterface = $this->getMockBuilder(PageSearchResultsInterface::class)
+            ->onlyMethods(['getTotalCount'])
+            ->getMock();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 
         /** @var PageRepositoryInterface | MockObject $cmsRepository */

--- a/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
+++ b/Test/Unit/Aggregator/Cms/CmsPageCountAggregatorUnitTest.php
@@ -32,7 +32,7 @@ final class CmsPageCountAggregatorUnitTest extends TestCase
         $updateMetricService->expects($this->once())->method('update')->willReturn(true);
 
         $searchResultInterface = $this->getMockBuilder(PageSearchResultsInterface::class)
-            ->onlyMethods(['getTotalCount', 'getItems', 'setItems', 'getSearchCriteria', 'setSearchCriteria'])
+            ->onlyMethods(['getTotalCount', 'setTotalCount','getItems', 'setItems', 'getSearchCriteria', 'setSearchCriteria'])
             ->getMock();
         $searchResultInterface->expects($this->once())->method('getTotalCount')->willReturn('10');
 

--- a/Test/Unit/Aggregator/Index/IndexerChangelogCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Index/IndexerChangelogCountAggregatorTest.php
@@ -165,8 +165,8 @@ class IndexerChangelogCountAggregatorTest extends TestCase
         } else {
             $connection->expects($this->exactly(2))
                        ->method('fetchOne')
-                       ->will(
-                           $this->returnCallback(function ($arg) use ($select1, $select2) {
+                       ->willReturnCallback(
+                           function ($arg) use ($select1, $select2) {
                                if (spl_object_id($select1) === spl_object_id($arg)) {
                                    throw new \Zend_Db_Exception(self::EXCEPTION_1);
                                } elseif (spl_object_id($select2) === spl_object_id($arg)) {
@@ -174,7 +174,7 @@ class IndexerChangelogCountAggregatorTest extends TestCase
                                } else {
                                    return 20;
                                }
-                           })
+                           }
                        );
         }
     }

--- a/Test/Unit/Aggregator/Index/IndexerLastCallSecondsCountTest.php
+++ b/Test/Unit/Aggregator/Index/IndexerLastCallSecondsCountTest.php
@@ -159,8 +159,8 @@ class IndexerLastCallSecondsCountTest extends TestCase
         } else {
             $connection->expects($this->exactly(2))
                        ->method('fetchOne')
-                       ->will(
-                           $this->returnCallback(function ($arg) use ($select1, $select2) {
+                       ->willReturnCallback(
+                           function ($arg) use ($select1, $select2) {
                                if (spl_object_id($select1) === spl_object_id($arg)) {
                                    throw new \Zend_Db_Exception('ERROR NUMBER 1');
                                } elseif (spl_object_id($select2) === spl_object_id($arg)) {
@@ -168,7 +168,7 @@ class IndexerLastCallSecondsCountTest extends TestCase
                                } else {
                                    return 20;
                                }
-                           })
+                           }
                        );
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "magento/module-config": "*",
     "magento/module-backend": "*",
     "guzzlehttp/guzzle": "^7.4.5",
-    "symfony/console": "^5.4.46|^6.0|^7.0",
+    "symfony/console": "^5.4.46|^6.0",
     "psr/log": "^1.1|^2.0|^3.0",
     "monolog/monolog": "^2.9.0|^3.0",
     "magento/module-store": "*",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "magento/module-config": "*",
     "magento/module-backend": "*",
     "guzzlehttp/guzzle": "^7.4.5",
-    "symfony/console": "^5.4.46|^6.0",
+    "symfony/console": "^5.4.46|^6.0|^7.0",
     "psr/log": "^1.1|^2.0|^3.0",
     "monolog/monolog": "^2.9.0|^3.0",
     "magento/module-store": "*",


### PR DESCRIPTION
This pull request adds compatibility to Magento 2.4.9. Changes were:

- Remove deprecations from unit tests
- Add support for symfony/console ^7.0