### PR TITLE
Fix N+1 full-table scan in order item aggregators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `OrderItemCountAggregator` / `OrderItemAmountAggregator`: replaced the per-order N+1 collection loading (full `sales_order` scan plus one order-item collection load per order, every cron minute) with a single streamed query over `sales_order_item`. Item status is derived from the qty columns mirroring `Magento\Sales\Model\Order\Item::getStatusId()`, including children-inherited backorder; emitted series and labels are unchanged. The aggregators no longer unserialize `product_options`, so a corrupt row cannot abort the whole metric anymore.
+
 ## [4.1.0] - 2026-05-28
 
 ### Changed

--- a/Test/Unit/Aggregator/Order/OrderItemAggregatorStatusDerivationTest.php
+++ b/Test/Unit/Aggregator/Order/OrderItemAggregatorStatusDerivationTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Order;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Sales\Model\Order\Item;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Order\OrderItemCountAggregator;
+
+/**
+ * The order item aggregators derive item status from raw qty columns instead
+ * of hydrating Item models. This suite pins that derivation to the framework:
+ * every ladder branch of Item::getStatusId(), including children-inherited
+ * backorder and the orphan-child edge, must return the identical status id
+ * as a real Magento\Sales\Model\Order\Item fed the same values.
+ */
+final class OrderItemAggregatorStatusDerivationTest extends TestCase
+{
+    private ObjectManager $objectManager;
+
+    private $getStatusId;
+
+    private $getChildrenMap;
+
+    private object $aggregatorInstance;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $ref = new \ReflectionClass(OrderItemCountAggregator::class);
+
+        $this->getStatusId = $ref->getMethod('getStatusId');
+        $this->getStatusId->setAccessible(true);
+
+        $this->getChildrenMap = $ref->getMethod('getChildrenQtyBackorderedByParentId');
+        $this->getChildrenMap->setAccessible(true);
+
+        $this->aggregatorInstance = $ref->newInstanceWithoutConstructor();
+    }
+
+    private function makeRow(
+        int $itemId,
+        $parentItemId,
+        $qtyBackordered,
+        $qtyCanceled,
+        $qtyInvoiced,
+        $qtyOrdered,
+        $qtyRefunded,
+        $qtyShipped
+    ): array {
+        return [
+            'item_id' => $itemId,
+            'parent_item_id' => $parentItemId,
+            'qty_backordered' => $qtyBackordered,
+            'qty_canceled' => $qtyCanceled,
+            'qty_invoiced' => $qtyInvoiced,
+            'qty_ordered' => $qtyOrdered,
+            'qty_refunded' => $qtyRefunded,
+            'qty_shipped' => $qtyShipped,
+        ];
+    }
+
+    private function makeRealItem(array $row): Item
+    {
+        /** @var Item $item */
+        $item = $this->objectManager->getObject(Item::class);
+        $item->setQtyBackordered($row['qty_backordered']);
+        $item->setQtyCanceled($row['qty_canceled']);
+        $item->setQtyInvoiced($row['qty_invoiced']);
+        $item->setQtyOrdered($row['qty_ordered']);
+        $item->setQtyRefunded($row['qty_refunded']);
+        $item->setQtyShipped($row['qty_shipped']);
+
+        return $item;
+    }
+
+    public function testItMatchesItemGetStatusIdForEveryLadderBranch(): void
+    {
+        $scenarios = [
+            'pending' => [0, 0, 0, null, 0, 0, Item::STATUS_PENDING],
+            'pending, zero-qty edge (0 not null)' => [0, 0, 0, 0, 0, 0, Item::STATUS_PENDING],
+            'shipped' => [0, 10, 1, 100, 10, 80, Item::STATUS_SHIPPED],
+            'shipped, own backordered set but shipped satisfied first' => [1, 10, 1, 100, 10, 80, Item::STATUS_SHIPPED],
+            'mixed (shipped branch fails on qty mismatch)' => [1, 10, 1, 100, 10, 99, Item::STATUS_MIXED],
+            'invoiced' => [0, 10, 80, 100, 10, 0, Item::STATUS_INVOICED],
+            'invoiced, own backordered set but invoiced satisfied first' => [1, 10, 80, 100, 10, 0, Item::STATUS_INVOICED],
+            'mixed (invoiced branch fails on qty mismatch)' => [1, 10, 99, 100, 10, 0, Item::STATUS_MIXED],
+            'backordered-own' => [80, 10, null, 100, 10, null, Item::STATUS_BACKORDERED],
+            'refunded' => [null, null, null, 9, 9, null, Item::STATUS_REFUNDED],
+            'canceled' => [null, 9, null, 9, null, null, Item::STATUS_CANCELED],
+            'partial' => [1, 10, 70, 100, 10, 79, Item::STATUS_PARTIAL],
+            'partial, zero backordered' => [0, 10, 70, 100, 10, 79, Item::STATUS_PARTIAL],
+            'float partials (qty_ordered 3, shipped 1.5)' => [0, 0, 0, 3, 0, 1.5, Item::STATUS_PARTIAL],
+        ];
+
+        foreach ($scenarios as $name => $scenario) {
+            [$qtyBackordered, $qtyCanceled, $qtyInvoiced, $qtyOrdered, $qtyRefunded, $qtyShipped, $expectedStatus] = $scenario;
+
+            $row = $this->makeRow(1, null, $qtyBackordered, $qtyCanceled, $qtyInvoiced, $qtyOrdered, $qtyRefunded, $qtyShipped);
+
+            $actualFromAggregator = $this->getStatusId->invoke($this->aggregatorInstance, $row, []);
+
+            $realItem = $this->makeRealItem($row);
+            $actualFromCoreModel = $realItem->getStatusId();
+
+            $this->assertSame($expectedStatus, $actualFromCoreModel, $name . ': fixture disagrees with core Item model');
+            $this->assertSame($expectedStatus, $actualFromAggregator, $name . ': derivation disagrees with core Item model');
+        }
+    }
+
+    public function testItMatchesItemGetStatusIdForChildrenInheritedBackorder(): void
+    {
+        $parentRow = $this->makeRow(10, null, 0, 0, 0, 5, 0, 0);
+        $childRow = $this->makeRow(11, 10, 5, 0, 0, 5, 0, 0);
+        $orderBuffer = [$parentRow, $childRow];
+
+        $childrenMap = $this->getChildrenMap->invoke($this->aggregatorInstance, $orderBuffer);
+
+        $actualParentStatus = $this->getStatusId->invoke($this->aggregatorInstance, $parentRow, $childrenMap);
+        $actualChildStatus = $this->getStatusId->invoke($this->aggregatorInstance, $childRow, $childrenMap);
+
+        $realParent = $this->makeRealItem($parentRow);
+        $realChild = $this->makeRealItem($childRow);
+        $realChild->setParentItem($realParent);
+
+        $this->assertTrue($realParent->getHasChildren());
+        $this->assertSame(Item::STATUS_BACKORDERED, $realParent->getStatusId(), 'fixture disagrees with core Item model for parent');
+        $this->assertSame(Item::STATUS_BACKORDERED, $actualParentStatus, 'derivation disagrees with core Item model for children-inherited backorder (parent)');
+
+        $this->assertSame($realChild->getStatusId(), $actualChildStatus, 'derivation disagrees with core Item model for children-inherited backorder (child, own status unaffected)');
+    }
+
+    public function testItMatchesItemGetStatusIdForOrphanChildWithNoInheritance(): void
+    {
+        $orphanRow = $this->makeRow(20, 999, 3, 0, 0, 3, 0, 0);
+        $orderBuffer = [$orphanRow];
+
+        $childrenMap = $this->getChildrenMap->invoke($this->aggregatorInstance, $orderBuffer);
+        $this->assertArrayNotHasKey(20, $childrenMap, 'orphan child item_id must never be a key (it is not anyone\'s parent)');
+
+        $actualOrphanStatus = $this->getStatusId->invoke($this->aggregatorInstance, $orphanRow, $childrenMap);
+
+        $realOrphan = $this->makeRealItem($orphanRow);
+        $realOrphan->setParentItem(null);
+
+        $this->assertSame(Item::STATUS_BACKORDERED, $realOrphan->getStatusId(), 'fixture disagrees with core Item model for orphan');
+        $this->assertSame($realOrphan->getStatusId(), $actualOrphanStatus, 'derivation disagrees with core Item model for orphan child (no inheritance from a deleted parent)');
+    }
+}

--- a/Test/Unit/Aggregator/Order/OrderItemAggregatorStatusDerivationTest.php
+++ b/Test/Unit/Aggregator/Order/OrderItemAggregatorStatusDerivationTest.php
@@ -33,10 +33,7 @@ final class OrderItemAggregatorStatusDerivationTest extends TestCase
         $ref = new \ReflectionClass(OrderItemCountAggregator::class);
 
         $this->getStatusId = $ref->getMethod('getStatusId');
-        $this->getStatusId->setAccessible(true);
-
         $this->getChildrenMap = $ref->getMethod('getChildrenQtyBackorderedByParentId');
-        $this->getChildrenMap->setAccessible(true);
 
         $this->aggregatorInstance = $ref->newInstanceWithoutConstructor();
     }

--- a/src/Aggregator/Order/OrderItemAmountAggregator.php
+++ b/src/Aggregator/Order/OrderItemAmountAggregator.php
@@ -4,30 +4,23 @@ declare(strict_types=1);
 
 namespace RunAsRoot\PrometheusExporter\Aggregator\Order;
 
-use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Model\Order\Item;
-use Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory as OrderItemCollectionFactory;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
-use function array_key_exists;
-use function count;
 
 class OrderItemAmountAggregator implements MetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_items_amount_total';
 
     private UpdateMetricService $updateMetricService;
-    private OrderItemCollectionFactory $orderItemCollectionFactory;
     private ResourceConnection $resourceConnection;
 
     public function __construct(
         UpdateMetricService $updateMetricService,
-        OrderItemCollectionFactory $orderItemCollectionFactory,
         ResourceConnection $resourceConnection
     ) {
         $this->updateMetricService = $updateMetricService;
-        $this->orderItemCollectionFactory = $orderItemCollectionFactory;
         $this->resourceConnection = $resourceConnection;
     }
 
@@ -50,51 +43,155 @@ class OrderItemAmountAggregator implements MetricAggregatorInterface
     {
         $connection = $this->resourceConnection->getConnection();
 
-        $salesOrderTable = $connection->getTableName('sales_order'); 
-        $storeTable = $connection->getTableName('store');        $query = 'SELECT ' . $salesOrderTable . '.entity_id AS ORDER_ID, ' . $storeTable . '.code AS STORE_CODE' .
-            ' FROM ' . $salesOrderTable .
+        $orderItemTable = $connection->getTableName('sales_order_item');
+        $salesOrderTable = $connection->getTableName('sales_order');
+        $storeTable = $connection->getTableName('store');
+
+        $select = 'SELECT ' . $orderItemTable . '.item_id, ' . $orderItemTable . '.order_id, ' .
+            $orderItemTable . '.parent_item_id, ' . $orderItemTable . '.qty_backordered, ' .
+            $orderItemTable . '.qty_canceled, ' . $orderItemTable . '.qty_invoiced, ' .
+            $orderItemTable . '.qty_ordered, ' . $orderItemTable . '.qty_refunded, ' .
+            $orderItemTable . '.qty_shipped, ' . $orderItemTable . '.row_total_incl_tax, ' .
+            $storeTable . '.code AS store_code' .
+            ' FROM ' . $orderItemTable .
+            ' INNER JOIN ' . $salesOrderTable .
+            ' ON ' . $orderItemTable . '.order_id = ' . $salesOrderTable . '.entity_id' .
             ' INNER JOIN ' . $storeTable .
-            ' ON ' . $salesOrderTable . '.`store_id` = ' . $storeTable . '.store_id';
+            ' ON ' . $storeTable . '.store_id = ' . $salesOrderTable . '.store_id' .
+            ' ORDER BY ' . $orderItemTable . '.order_id, ' . $orderItemTable . '.item_id';
 
-        $ordersAndStores = $connection->fetchAll($query);
-
-        if (count($ordersAndStores) === 0) {
-            return true;
-        }
+        $statement = $connection->query($select);
 
         $grandTotalsByStore = [];
+        $orderBuffer = [];
+        $bufferedOrderId = null;
 
-        foreach ($ordersAndStores as $orderAndStore) {
-            $orderId = $orderAndStore['ORDER_ID'] ?? 0;
-            $storeCode = $orderAndStore['STORE_CODE'] ?? '';
-
-            if (!array_key_exists($storeCode, $grandTotalsByStore)) {
-                $grandTotalsByStore[$storeCode] = [];
+        while ($row = $statement->fetch()) {
+            if (null !== $bufferedOrderId && $row['order_id'] != $bufferedOrderId) {
+                $this->addOrderItemAmounts($orderBuffer, $grandTotalsByStore);
+                $orderBuffer = [];
             }
 
-            $orderItemCollection = $this->orderItemCollectionFactory->create();
-            $searchResults = $orderItemCollection->addFilter('order_id', $orderId);
+            $bufferedOrderId = $row['order_id'];
+            $orderBuffer[] = $row;
+        }
 
-            foreach ($searchResults->getItems() as $orderItem) {
-                /** @var Item $orderItem */
-                $status = (string)$orderItem->getStatus();
-
-                if (!array_key_exists($status, $grandTotalsByStore[$storeCode])) {
-                    $grandTotalsByStore[$storeCode][$status] = 0.0;
-                }
-
-                $grandTotalsByStore[$storeCode][$status] += $orderItem->getRowTotalInclTax();
-            }
+        if (\count($orderBuffer) > 0) {
+            $this->addOrderItemAmounts($orderBuffer, $grandTotalsByStore);
         }
 
         foreach ($grandTotalsByStore as $storeCode => $grandTotals) {
             foreach ($grandTotals as $status => $grandTotal) {
-                $labels = [ 'status' => $status, 'store_code' => $storeCode ];
+                $labels = ['status' => $status, 'store_code' => $storeCode];
 
-                $this->updateMetricService->update(self::METRIC_CODE, (string)$grandTotal, $labels);
+                $this->updateMetricService->update(self::METRIC_CODE, (string) $grandTotal, $labels);
             }
         }
 
         return true;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>>    $orderItemRows
+     * @param array<string, array<string, float>> $grandTotalsByStore
+     */
+    private function addOrderItemAmounts(array $orderItemRows, array &$grandTotalsByStore): void
+    {
+        $childrenQtyBackorderedByParentId = $this->getChildrenQtyBackorderedByParentId($orderItemRows);
+
+        foreach ($orderItemRows as $row) {
+            $status = (string) Item::getStatusName((string) $this->getStatusId($row, $childrenQtyBackorderedByParentId));
+            $storeCode = (string) ($row['store_code'] ?? '');
+
+            if (!\array_key_exists($storeCode, $grandTotalsByStore)) {
+                $grandTotalsByStore[$storeCode] = [];
+            }
+
+            if (!\array_key_exists($status, $grandTotalsByStore[$storeCode])) {
+                $grandTotalsByStore[$storeCode][$status] = 0.0;
+            }
+
+            $grandTotalsByStore[$storeCode][$status] += $row['row_total_incl_tax'];
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $orderItemRows
+     *
+     * @return array<int|string, float>
+     */
+    private function getChildrenQtyBackorderedByParentId(array $orderItemRows): array
+    {
+        $childrenQtyBackorderedByParentId = [];
+
+        foreach ($orderItemRows as $row) {
+            if (null === $row['parent_item_id']) {
+                continue;
+            }
+
+            if (!\array_key_exists($row['parent_item_id'], $childrenQtyBackorderedByParentId)) {
+                $childrenQtyBackorderedByParentId[$row['parent_item_id']] = 0.0;
+            }
+
+            $childrenQtyBackorderedByParentId[$row['parent_item_id']] += (float) $row['qty_backordered'];
+        }
+
+        return $childrenQtyBackorderedByParentId;
+    }
+
+    /**
+     * Mirrors Magento\Sales\Model\Order\Item::getStatusId().
+     *
+     * @param array<string, mixed>     $row
+     * @param array<int|string, float> $childrenQtyBackorderedByParentId
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    private function getStatusId(array $row, array $childrenQtyBackorderedByParentId): int
+    {
+        $backordered = (float) $row['qty_backordered'];
+
+        if (!$backordered && \array_key_exists($row['item_id'], $childrenQtyBackorderedByParentId)) {
+            $backordered = $childrenQtyBackorderedByParentId[$row['item_id']];
+        }
+
+        $canceled = (float) $row['qty_canceled'];
+        $invoiced = (float) $row['qty_invoiced'];
+        $ordered = (float) $row['qty_ordered'];
+        $refunded = (float) $row['qty_refunded'];
+        $shipped = (float) $row['qty_shipped'];
+
+        $actuallyOrdered = $ordered - $canceled - $refunded;
+
+        if (!$invoiced && !$shipped && !$refunded && !$canceled && !$backordered) {
+            return Item::STATUS_PENDING;
+        }
+
+        if ($shipped && $invoiced && $actuallyOrdered == $shipped) {
+            return Item::STATUS_SHIPPED;
+        }
+
+        if ($invoiced && !$shipped && $actuallyOrdered == $invoiced) {
+            return Item::STATUS_INVOICED;
+        }
+
+        if ($backordered && $actuallyOrdered == $backordered) {
+            return Item::STATUS_BACKORDERED;
+        }
+
+        if ($refunded && $ordered == $refunded) {
+            return Item::STATUS_REFUNDED;
+        }
+
+        if ($canceled && $ordered == $canceled) {
+            return Item::STATUS_CANCELED;
+        }
+
+        if (max($shipped, $invoiced) < $actuallyOrdered) {
+            return Item::STATUS_PARTIAL;
+        }
+
+        return Item::STATUS_MIXED;
     }
 }

--- a/src/Aggregator/Order/OrderItemCountAggregator.php
+++ b/src/Aggregator/Order/OrderItemCountAggregator.php
@@ -6,26 +6,21 @@ namespace RunAsRoot\PrometheusExporter\Aggregator\Order;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Model\Order\Item;
-use Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory as OrderItemCollectionFactory;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
-use function array_key_exists;
 
 class OrderItemCountAggregator implements MetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_items_count_total';
 
     private UpdateMetricService $updateMetricService;
-    private OrderItemCollectionFactory $orderItemCollectionFactory;
     private ResourceConnection $resourceConnection;
 
     public function __construct(
         UpdateMetricService $updateMetricService,
-        OrderItemCollectionFactory $orderItemCollectionFactory,
         ResourceConnection $resourceConnection
     ) {
         $this->updateMetricService = $updateMetricService;
-        $this->orderItemCollectionFactory = $orderItemCollectionFactory;
         $this->resourceConnection = $resourceConnection;
     }
 
@@ -48,51 +43,155 @@ class OrderItemCountAggregator implements MetricAggregatorInterface
     {
         $connection = $this->resourceConnection->getConnection();
 
-        $salesOrderTable = $connection->getTableName('sales_order'); 
-        $storeTable = $connection->getTableName('store');        $query = 'SELECT ' . $salesOrderTable . '.entity_id AS ORDER_ID, ' . $storeTable . '.code AS STORE_CODE' .
-            ' FROM ' . $salesOrderTable .
+        $orderItemTable = $connection->getTableName('sales_order_item');
+        $salesOrderTable = $connection->getTableName('sales_order');
+        $storeTable = $connection->getTableName('store');
+
+        $select = 'SELECT ' . $orderItemTable . '.item_id, ' . $orderItemTable . '.order_id, ' .
+            $orderItemTable . '.parent_item_id, ' . $orderItemTable . '.qty_backordered, ' .
+            $orderItemTable . '.qty_canceled, ' . $orderItemTable . '.qty_invoiced, ' .
+            $orderItemTable . '.qty_ordered, ' . $orderItemTable . '.qty_refunded, ' .
+            $orderItemTable . '.qty_shipped, ' . $orderItemTable . '.row_total_incl_tax, ' .
+            $storeTable . '.code AS store_code' .
+            ' FROM ' . $orderItemTable .
+            ' INNER JOIN ' . $salesOrderTable .
+            ' ON ' . $orderItemTable . '.order_id = ' . $salesOrderTable . '.entity_id' .
             ' INNER JOIN ' . $storeTable .
-            ' ON ' . $salesOrderTable . '.`store_id` = ' . $storeTable . '.store_id';
+            ' ON ' . $storeTable . '.store_id = ' . $salesOrderTable . '.store_id' .
+            ' ORDER BY ' . $orderItemTable . '.order_id, ' . $orderItemTable . '.item_id';
 
-        $ordersAndStores = $connection->fetchAll($query);
-
-        if (count($ordersAndStores) === 0) {
-            return true;
-        }
+        $statement = $connection->query($select);
 
         $countByStore = [];
+        $orderBuffer = [];
+        $bufferedOrderId = null;
 
-        foreach ($ordersAndStores as $orderAndStore) {
-            $orderId = $orderAndStore['ORDER_ID'] ?? 0;
-            $storeCode = $orderAndStore['STORE_CODE'] ?? '';
-
-            if (!array_key_exists($storeCode, $countByStore)) {
-                $countByStore[$storeCode] = [];
+        while ($row = $statement->fetch()) {
+            if (null !== $bufferedOrderId && $row['order_id'] != $bufferedOrderId) {
+                $this->countOrderItems($orderBuffer, $countByStore);
+                $orderBuffer = [];
             }
 
-            $orderItemCollection = $this->orderItemCollectionFactory->create();
-            $searchResults = $orderItemCollection->addFilter('order_id', $orderId);
+            $bufferedOrderId = $row['order_id'];
+            $orderBuffer[] = $row;
+        }
 
-            foreach ($searchResults->getItems() as $orderItem) {
-                /** @var Item $orderItem */
-                $status = (string)$orderItem->getStatus();
-
-                if (!array_key_exists($status, $countByStore[$storeCode])) {
-                    $countByStore[$storeCode][$status] = 0;
-                }
-
-                $countByStore[$storeCode][$status]++;
-            }
+        if (\count($orderBuffer) > 0) {
+            $this->countOrderItems($orderBuffer, $countByStore);
         }
 
         foreach ($countByStore as $storeCode => $countByState) {
             foreach ($countByState as $status => $count) {
-                $labels = [ 'status' => $status, 'store_code' => $storeCode ];
+                $labels = ['status' => $status, 'store_code' => $storeCode];
 
-                $this->updateMetricService->update(self::METRIC_CODE, (string)$count, $labels);
+                $this->updateMetricService->update(self::METRIC_CODE, (string) $count, $labels);
             }
         }
 
         return true;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>>  $orderItemRows
+     * @param array<string, array<string, int>> $countByStore
+     */
+    private function countOrderItems(array $orderItemRows, array &$countByStore): void
+    {
+        $childrenQtyBackorderedByParentId = $this->getChildrenQtyBackorderedByParentId($orderItemRows);
+
+        foreach ($orderItemRows as $row) {
+            $status = (string) Item::getStatusName((string) $this->getStatusId($row, $childrenQtyBackorderedByParentId));
+            $storeCode = (string) ($row['store_code'] ?? '');
+
+            if (!\array_key_exists($storeCode, $countByStore)) {
+                $countByStore[$storeCode] = [];
+            }
+
+            if (!\array_key_exists($status, $countByStore[$storeCode])) {
+                $countByStore[$storeCode][$status] = 0;
+            }
+
+            ++$countByStore[$storeCode][$status];
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $orderItemRows
+     *
+     * @return array<int|string, float>
+     */
+    private function getChildrenQtyBackorderedByParentId(array $orderItemRows): array
+    {
+        $childrenQtyBackorderedByParentId = [];
+
+        foreach ($orderItemRows as $row) {
+            if (null === $row['parent_item_id']) {
+                continue;
+            }
+
+            if (!\array_key_exists($row['parent_item_id'], $childrenQtyBackorderedByParentId)) {
+                $childrenQtyBackorderedByParentId[$row['parent_item_id']] = 0.0;
+            }
+
+            $childrenQtyBackorderedByParentId[$row['parent_item_id']] += (float) $row['qty_backordered'];
+        }
+
+        return $childrenQtyBackorderedByParentId;
+    }
+
+    /**
+     * Mirrors Magento\Sales\Model\Order\Item::getStatusId().
+     *
+     * @param array<string, mixed>     $row
+     * @param array<int|string, float> $childrenQtyBackorderedByParentId
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
+     */
+    private function getStatusId(array $row, array $childrenQtyBackorderedByParentId): int
+    {
+        $backordered = (float) $row['qty_backordered'];
+
+        if (!$backordered && \array_key_exists($row['item_id'], $childrenQtyBackorderedByParentId)) {
+            $backordered = $childrenQtyBackorderedByParentId[$row['item_id']];
+        }
+
+        $canceled = (float) $row['qty_canceled'];
+        $invoiced = (float) $row['qty_invoiced'];
+        $ordered = (float) $row['qty_ordered'];
+        $refunded = (float) $row['qty_refunded'];
+        $shipped = (float) $row['qty_shipped'];
+
+        $actuallyOrdered = $ordered - $canceled - $refunded;
+
+        if (!$invoiced && !$shipped && !$refunded && !$canceled && !$backordered) {
+            return Item::STATUS_PENDING;
+        }
+
+        if ($shipped && $invoiced && $actuallyOrdered == $shipped) {
+            return Item::STATUS_SHIPPED;
+        }
+
+        if ($invoiced && !$shipped && $actuallyOrdered == $invoiced) {
+            return Item::STATUS_INVOICED;
+        }
+
+        if ($backordered && $actuallyOrdered == $backordered) {
+            return Item::STATUS_BACKORDERED;
+        }
+
+        if ($refunded && $ordered == $refunded) {
+            return Item::STATUS_REFUNDED;
+        }
+
+        if ($canceled && $ordered == $canceled) {
+            return Item::STATUS_CANCELED;
+        }
+
+        if (max($shipped, $invoiced) < $actuallyOrdered) {
+            return Item::STATUS_PARTIAL;
+        }
+
+        return Item::STATUS_MIXED;
     }
 }


### PR DESCRIPTION
## Problem

`OrderItemCountAggregator` and `OrderItemAmountAggregator` fetch every `sales_order` row and then load one order-item collection per order, on every run of the every-minute `rar_prometheus_aggregate_metrics` cron. On a production store this makes a single run exceed the one-minute schedule, so the next tick fails the per-job cron lock (observed: ~22.5k 'Could not acquire lock' Sentry events in 28 days on one store). Collection hydration also unserializes `product_options` for every row, so a single corrupt value aborts the whole metric before any series is written (~4k additional Sentry events, both gauges permanently stale on the affected store).

## Fix

Both aggregators now stream a single query over `sales_order_item` (joined to `sales_order` and `store`), buffered one order at a time, and derive the item status from the qty columns, mirroring `Magento\Sales\Model\Order\Item::getStatusId()` exactly, including children-inherited backorder and the orphan-child edge. `product_options` is never selected. Emitted series (status label via `Item::getStatusName()`, `store_code`) are unchanged. The now-unused `OrderItemCollectionFactory` constructor argument was removed (no di.xml argument overrides exist for these classes).

## Equivalence evidence

- New unit suite `Test/Unit/Aggregator/Order/OrderItemAggregatorStatusDerivationTest.php` pins the derivation to the framework implementation: every `getStatusId()` ladder branch, children-inherited backorder, and orphan-child are asserted against a real `Magento\Sales\Model\Order\Item` fed identical values.
- On a production-copy database (2051 order-item rows): full readback of `run_as_root_prometheus_metrics` for both codes is byte-identical before vs after the change, and an independent SQL recomputation of `(store_code, status) => count/sum` matches exactly.

## Notes for review

- Status derivation intentionally replicates core's loose `==` float comparisons and branch order; do not 'clean up' without re-verifying equivalence.
- `Item::getStatusName()` is called with a `(string)` cast to satisfy the core docblock (`@param string $statusId`); array key lookup is unaffected.
- CHANGELOG has an Unreleased entry. A 3.2.x backport is planned after review (consumers pinned to ^3.2).