### PR TITLE
Skip indexers without changelog tables in indexer aggregators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.2] - 2026-07-09
+
+### Fixed
+
+- `IndexerBacklogCountAggregator` / `IndexerChangelogCountAggregator`: skip indexers that are not in Update by Schedule mode, since those never have a `*_cl` changelog table and were erroring on every cron run. `IndexerBacklogCountAggregator` also catches `ChangelogTableNotExistsException` per indexer and logs it instead of aborting the whole aggregation, so one missing table can no longer stop the backlog metric from updating for every other indexer.
+
 ## [4.2.1] - 2026-07-09
 
 ### Fixed

--- a/Test/Unit/Aggregator/Index/IndexerBacklogCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Index/IndexerBacklogCountAggregatorTest.php
@@ -6,12 +6,15 @@ namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Index;
 
 use Magento\Framework\Indexer\IndexerInterface;
 use Magento\Framework\Mview\View\ChangelogInterface;
+use Magento\Framework\Mview\View\ChangelogTableNotExistsException;
 use Magento\Framework\Mview\ViewInterface;
+use Magento\Framework\Phrase;
 use Magento\Indexer\Model\Indexer\Collection;
 use Magento\Indexer\Model\Indexer\CollectionFactory;
 use Magento\Indexer\Model\Mview\View\State;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use RunAsRoot\PrometheusExporter\Aggregator\Index\IndexerBacklogCountAggregator;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
@@ -25,16 +28,22 @@ final class IndexerBacklogCountAggregatorTest extends TestCase
     private IndexerBacklogCountAggregator $sut;
     private MockObject|UpdateMetricServiceInterface $updateMetricService;
     private MockObject|Collection $indexerCollection;
+    private MockObject|LoggerInterface $logger;
 
     protected function setUp(): void
     {
         $this->updateMetricService = $this->createMock(UpdateMetricService::class);
         $indexerCollectionFactory = $this->createMock(CollectionFactory::class);
         $this->indexerCollection = $this->createMock(Collection::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $indexerCollectionFactory->method('create')->willReturn($this->indexerCollection);
 
-        $this->sut = new IndexerBacklogCountAggregator($this->updateMetricService, $indexerCollectionFactory);
+        $this->sut = new IndexerBacklogCountAggregator(
+            $this->updateMetricService,
+            $indexerCollectionFactory,
+            $this->logger
+        );
     }
 
     public function testItAggregatesIndexersChangelogCount(): void
@@ -57,6 +66,8 @@ final class IndexerBacklogCountAggregatorTest extends TestCase
 
         $indexer1->method('getTitle')->willReturn(self::VIEW_ID_1);
         $indexer2->method('getTitle')->willReturn(self::VIEW_ID_2);
+        $indexer1->method('isScheduled')->willReturn(true);
+        $indexer2->method('isScheduled')->willReturn(true);
 
         $indexer1->expects($this->once())->method('getView')->willReturn($view1);
         $indexer2->expects($this->once())->method('getView')->willReturn($view2);
@@ -77,30 +88,68 @@ final class IndexerBacklogCountAggregatorTest extends TestCase
             ->with($testStateVersion2, $testCurrentVersionId2)
             ->willReturn(range(1, $testPendingCount2));
 
-        $this->indexerCollection->expects($this->once())->method('getItems')->willReturn([ $indexer1, $indexer2 ]);
+        $this->indexerCollection->expects($this->once())->method('getItems')->willReturn([$indexer1, $indexer2]);
 
-        $lables1 = [ 'title' => self::VIEW_ID_1 ];
-        $lables2 = [ 'title' => self::VIEW_ID_2 ];
+        $lables1 = ['title' => self::VIEW_ID_1];
+        $lables2 = ['title' => self::VIEW_ID_2];
 
         $callCount = 0;
         $this->updateMetricService
             ->expects($this->exactly(2))
             ->method('update')
             ->willReturnCallback(function (...$args) use (&$callCount, $lables1, $lables2) {
-                $callCount++;
-                if ($callCount === 1) {
+                ++$callCount;
+                if (1 === $callCount) {
                     $expected = [self::METRIC_CODE, '11', $lables1];
-                    $this->assertEquals($expected, array_slice($args, 0, count($expected)));
+                    $this->assertEquals($expected, \array_slice($args, 0, \count($expected)));
+
                     return true;
                 }
-                if ($callCount === 2) {
+                if (2 === $callCount) {
                     $expected = [self::METRIC_CODE, '22', $lables2];
-                    $this->assertEquals($expected, array_slice($args, 0, count($expected)));
+                    $this->assertEquals($expected, \array_slice($args, 0, \count($expected)));
+
                     return true;
                 }
+
                 return true;
             });
 
         $this->sut->aggregate();
+    }
+
+    public function testItSkipsIndexersThatAreNotScheduled(): void
+    {
+        $indexer = $this->createMock(IndexerInterface::class);
+        $indexer->method('isScheduled')->willReturn(false);
+        $indexer->expects($this->never())->method('getView');
+
+        $this->indexerCollection->expects($this->once())->method('getItems')->willReturn([$indexer]);
+
+        $this->updateMetricService->expects($this->never())->method('update');
+
+        $this->assertTrue($this->sut->aggregate());
+    }
+
+    public function testItLogsAndContinuesWhenChangelogTableIsMissing(): void
+    {
+        $indexer = $this->createMock(IndexerInterface::class);
+        $view = $this->createMock(ViewInterface::class);
+        $changelog = $this->createMock(ChangelogInterface::class);
+
+        $indexer->method('isScheduled')->willReturn(true);
+        $indexer->method('getTitle')->willReturn(self::VIEW_ID_1);
+        $indexer->expects($this->once())->method('getView')->willReturn($view);
+        $view->expects($this->once())->method('getChangelog')->willReturn($changelog);
+        $changelog->method('getVersion')->willThrowException(
+            new ChangelogTableNotExistsException(new Phrase('Table cataloginventory_stock_cl does not exist'))
+        );
+
+        $this->indexerCollection->expects($this->once())->method('getItems')->willReturn([$indexer]);
+
+        $this->logger->expects($this->once())->method('error');
+        $this->updateMetricService->expects($this->never())->method('update');
+
+        $this->assertTrue($this->sut->aggregate());
     }
 }

--- a/Test/Unit/Aggregator/Index/IndexerChangelogCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Index/IndexerChangelogCountAggregatorTest.php
@@ -84,17 +84,20 @@ class IndexerChangelogCountAggregatorTest extends TestCase
             ->expects($this->exactly(2))
             ->method('update')
             ->willReturnCallback(function (...$args) use (&$updateCallCount, $labels1, $labels2) {
-                $updateCallCount++;
-                if ($updateCallCount === 1) {
+                ++$updateCallCount;
+                if (1 === $updateCallCount) {
                     $expected = [self::METRIC_CODE, '777', $labels1];
-                    $this->assertEquals($expected, array_slice($args, 0, count($expected)));
+                    $this->assertEquals($expected, \array_slice($args, 0, \count($expected)));
+
                     return true;
                 }
-                if ($updateCallCount === 2) {
+                if (2 === $updateCallCount) {
                     $expected = [self::METRIC_CODE, '888', $labels2];
-                    $this->assertEquals($expected, array_slice($args, 0, count($expected)));
+                    $this->assertEquals($expected, \array_slice($args, 0, \count($expected)));
+
                     return true;
                 }
+
                 return true;
             });
 
@@ -110,16 +113,18 @@ class IndexerChangelogCountAggregatorTest extends TestCase
         $this->logger
             ->expects($this->exactly(2))
             ->method('critical')
-            ->willReturnCallback(function (...$args) use (&$loggerCallCount) {
-                $loggerCallCount++;
-                if ($loggerCallCount === 1) {
+            ->willReturnCallback(function (...$args) use (&$loggerCallCount): void {
+                ++$loggerCallCount;
+                if (1 === $loggerCallCount) {
                     $expected = [self::EXCEPTION_1];
-                    $this->assertEquals($expected, array_slice($args, 0, count($expected)));
+                    $this->assertEquals($expected, \array_slice($args, 0, \count($expected)));
+
                     return;
                 }
-                if ($loggerCallCount === 2) {
+                if (2 === $loggerCallCount) {
                     $expected = [self::EXCEPTION_2];
-                    $this->assertEquals($expected, array_slice($args, 0, count($expected)));
+                    $this->assertEquals($expected, \array_slice($args, 0, \count($expected)));
+
                     return;
                 }
             });
@@ -129,6 +134,21 @@ class IndexerChangelogCountAggregatorTest extends TestCase
             ->method('update');
 
         $this->sut->aggregate();
+    }
+
+    public function testItSkipsIndexersThatAreNotScheduled(): void
+    {
+        $indexer = $this->createMock(IndexerInterface::class);
+        $indexer->method('isScheduled')->willReturn(false);
+        $indexer->expects($this->never())->method('getView');
+
+        $this->indexerCollection->expects($this->once())->method('getItems')->willReturn([$indexer]);
+        $this->resourceConnection->expects($this->once())->method('getConnection')
+                                 ->willReturn($this->createMock(AdapterInterface::class));
+
+        $this->updateMetricService->expects($this->never())->method('update');
+
+        $this->assertTrue($this->sut->aggregate());
     }
 
     private function setUpSelects(bool $throwException = false): void
@@ -147,7 +167,7 @@ class IndexerChangelogCountAggregatorTest extends TestCase
                    ->willReturnMap(
                        [
                            [self::TABLE_CHANGELOG_1, self::TABLE_CHANGELOG_1],
-                           [self::TABLE_CHANGELOG_2, self::TABLE_CHANGELOG_2]
+                           [self::TABLE_CHANGELOG_2, self::TABLE_CHANGELOG_2],
                        ]
                    );
         $select1 = $this->setUpSelectChangelog($select1, self::TABLE_CHANGELOG_1);
@@ -203,10 +223,12 @@ class IndexerChangelogCountAggregatorTest extends TestCase
         $indexer1->method('isValid')->willReturn(true);
         $indexer1->method('getTitle')->willReturn('indexer_name_1');
         $indexer1->method('getStatus')->willReturn('success');
+        $indexer1->method('isScheduled')->willReturn(true);
 
         $indexer2->method('isValid')->willReturn(true);
         $indexer2->method('getTitle')->willReturn('indexer_name_2');
         $indexer2->method('getStatus')->willReturn('failed');
+        $indexer2->method('isScheduled')->willReturn(true);
 
         $indexer1
             ->expects($this->once())

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "run_as_root/magento2-prometheus-exporter",
   "description": "Magento2 Prometheus Exporter",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "type": "magento2-module",
   "license": "MIT",
   "homepage": "https://github.com/run-as-root/magento2-prometheus-exporter",

--- a/src/Aggregator/Index/IndexerBacklogCountAggregator.php
+++ b/src/Aggregator/Index/IndexerBacklogCountAggregator.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace RunAsRoot\PrometheusExporter\Aggregator\Index;
 
 use Magento\Framework\Indexer\IndexerInterface;
+use Magento\Framework\Mview\View\ChangelogTableNotExistsException;
 use Magento\Indexer\Model\Indexer\CollectionFactory;
+use Psr\Log\LoggerInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 
@@ -15,7 +17,8 @@ class IndexerBacklogCountAggregator implements MetricAggregatorInterface
 
     public function __construct(
         private readonly UpdateMetricService $updateMetricService,
-        private readonly CollectionFactory $indexerCollectionFactory
+        private readonly CollectionFactory $indexerCollectionFactory,
+        private readonly LoggerInterface $logger
     ) {
     }
 
@@ -39,17 +42,26 @@ class IndexerBacklogCountAggregator implements MetricAggregatorInterface
         /** @var IndexerInterface[] $indexers */
         $indexers = $this->indexerCollectionFactory->create()->getItems();
         foreach ($indexers as $indexer) {
-            $labels = [ 'title' => $indexer->getTitle() ];
+            if (!$indexer->isScheduled()) {
+                continue;
+            }
+
+            $labels = ['title' => $indexer->getTitle()];
 
             $view = $indexer->getView();
             $changelog = $view->getChangelog();
             $state = $view->getState();
 
-            $currentVersionId = $changelog->getVersion();
-            $stateVersion = $state->getVersionId();
+            try {
+                $currentVersionId = $changelog->getVersion();
+                $stateVersion = $state->getVersionId();
 
-            $pendingCount = count($changelog->getList($stateVersion, $currentVersionId));
-            $this->updateMetricService->update(self::METRIC_CODE, (string)$pendingCount, $labels);
+                $pendingCount = \count($changelog->getList($stateVersion, $currentVersionId));
+                $this->updateMetricService->update(self::METRIC_CODE, (string) $pendingCount, $labels);
+            } catch (ChangelogTableNotExistsException $e) {
+                $this->logger->error($e->getMessage());
+                continue;
+            }
         }
 
         return true;

--- a/src/Aggregator/Index/IndexerChangelogCountAggregator.php
+++ b/src/Aggregator/Index/IndexerChangelogCountAggregator.php
@@ -23,12 +23,6 @@ class IndexerChangelogCountAggregator implements MetricAggregatorInterface
     private LoggerInterface $logger;
     private ResourceConnection $resourceConnection;
 
-    /**
-     * @param UpdateMetricService $updateMetricService
-     * @param CollectionFactory $indexerCollectionFactory
-     * @param ResourceConnection $resourceConnection
-     * @param LoggerInterface $logger
-     */
     public function __construct(
         UpdateMetricService $updateMetricService,
         CollectionFactory $indexerCollectionFactory,
@@ -63,6 +57,10 @@ class IndexerChangelogCountAggregator implements MetricAggregatorInterface
         $connection = $this->resourceConnection->getConnection();
 
         foreach ($this->indexerCollectionFactory->create()->getItems() as $index) {
+            if (!$index->isScheduled()) {
+                continue;
+            }
+
             $labels = [
                 'isValid' => $index->isValid(),
                 'title' => $index->getTitle(),
@@ -75,7 +73,7 @@ class IndexerChangelogCountAggregator implements MetricAggregatorInterface
 
             try {
                 $value = $this->getChangelogSize($connection, $changelog);
-                $this->updateMetricService->update(self::METRIC_CODE, (string)$value, $labels);
+                $this->updateMetricService->update(self::METRIC_CODE, (string) $value, $labels);
             } catch (\Zend_Db_Exception $e) {
                 $this->logger->critical($e->getMessage());
                 $result = false;
@@ -89,10 +87,7 @@ class IndexerChangelogCountAggregator implements MetricAggregatorInterface
      * Provide size of changelog table.
      * Avoid service contracts to get the exact data from DB.
      *
-     * @param AdapterInterface $adapter
      * @param Changelog $changelog
-     *
-     * @return int
      */
     private function getChangelogSize(AdapterInterface $adapter, ChangelogInterface $changelog): int
     {
@@ -101,6 +96,6 @@ class IndexerChangelogCountAggregator implements MetricAggregatorInterface
             ->reset(Select::COLUMNS)
             ->columns(['size' => 'count(version_id)']);
 
-        return (int)$adapter->fetchOne($select);
+        return (int) $adapter->fetchOne($select);
     }
 }


### PR DESCRIPTION
## Problem

On a production store, 17 distinct Sentry issues (~34k events over 28 days) trace back to `IndexerBacklogCountAggregator` and `IndexerChangelogCountAggregator` throwing `ChangelogTableNotExistsException` every minute. Any indexer that is not running in "Update by Schedule" mode (Update on Save, or a dummy/no-op view) never has a `*_cl` changelog table, but both aggregators unconditionally called `$view->getChangelog()` and read from it for every indexer in the collection.

Worse, `IndexerBacklogCountAggregator` had no exception handling at all: the very first indexer that hit a missing changelog table aborted the whole `foreach`, so the backlog metric stopped updating for every other indexer too, not just the broken one.

## Fix

- Both aggregators now skip an indexer at the top of the loop when `$indexer->isScheduled()` is false, since those indexers never have a changelog to read.
- `IndexerBacklogCountAggregator` wraps its per-indexer changelog read in a try/catch for `ChangelogTableNotExistsException`, logs the error, and continues to the next indexer instead of aborting. This is defense-in-depth for a scheduled indexer whose table was manually dropped (e.g. by a failed reindex).
- `IndexerChangelogCountAggregator` already had try/catch around its DB read (`\Zend_Db_Exception`); it only needed the `isScheduled()` guard.

## Test coverage

Extended both existing test classes in `Test/Unit/Aggregator/Index/`:
- `IndexerBacklogCountAggregatorTest`: new tests assert a non-scheduled indexer is skipped (no `getView()` call, no metric update), and that a `ChangelogTableNotExistsException` is logged and the loop continues without updating the metric for that indexer.
- `IndexerChangelogCountAggregatorTest`: new test asserts a non-scheduled indexer is skipped the same way.
- Existing scenarios updated to mock `isScheduled(): true` so prior coverage of the happy path and the `\Zend_Db_Exception` path is unaffected.

No merge, review only.

Release-ready as 4.2.2: version field and changelog are stamped in this PR; tag 4.2.2 on the merge commit.
