### PR TITLE
Prepare 4.2.1 release (fix Packagist-unconsumable 4.2.0 tag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.2.1] - 2026-07-09
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "run_as_root/magento2-prometheus-exporter",
   "description": "Magento2 Prometheus Exporter",
-  "version": "4.1.0",
+  "version": "4.2.1",
   "type": "magento2-module",
   "license": "MIT",
   "homepage": "https://github.com/run-as-root/magento2-prometheus-exporter",


### PR DESCRIPTION
The `4.2.0` tag was cut with `composer.json` still pinned to `"version": "4.1.0"`, so Packagist skips the tag (version field contradicts the tag name) and no consumer can install 4.2.0. Composer's VCS driver rejects it for the same reason, so there is no workaround on the consumer side.

This bumps the version field to `4.2.1` and stamps the changelog. After merge, tag `4.2.1` on the merge commit; Packagist will ingest it and `^4.2` constraints resolve. The dud `4.2.0` tag can stay or be deleted at your discretion.

Reminder from the repo docs: the pinned `version` field is intentional and must be bumped as part of every release.