### PR TITLE
Fix N+1 and unbounded full-table scans in order item aggregators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.3.0] - 2026-08-04
+
+### Added
+
+- `IntervalAwareMetricAggregatorInterface`: an optional interface an aggregator can implement to declare a minimum number of seconds between runs. `AggregateMetricsCron` skips such an aggregator until that interval has passed, using the Magento cache to remember the last successful run. Aggregators that do not implement it keep their existing per-cron-tick behaviour, so this is additive for third-party aggregators.
 
 ### Fixed
 
-- `OrderAmountAggregator`, `OrderItemAmountAggregator`, `OrderItemCountAggregator`: these still run an unbounded full-table scan on every cron tick even after the N+1 fix in 4.2.1, and were the largest contributors to the DB load reported in #69. They now implement a new `IntervalAwareMetricAggregatorInterface` so `AggregateMetricsCron` throttles them to once every 5 minutes instead of every minute, while every other (cheap) aggregator keeps its existing per-minute schedule.
+- `OrderAmountAggregator`, `OrderCountAggregator`, `OrderItemAmountAggregator`, `OrderItemCountAggregator`: all four still run an unbounded full-table scan over `sales_order` / `sales_order_item` on every cron tick even after the N+1 fix in 4.2.1, and are the largest contributors to the DB load reported in #69. They now implement `IntervalAwareMetricAggregatorInterface` and are throttled to once every 5 minutes instead of every minute, while every other (cheap) aggregator keeps its existing per-minute schedule.
 - `AggregateMetricsCron`: a cache-backend exception while checking/marking an interval-throttled aggregator's last run no longer aborts the rest of that cron tick's aggregator loop, and an aggregator whose `aggregate()` returns `false` (a soft failure) is no longer falsely marked as a successful run - it retries on the next tick instead of being suppressed for 5 minutes.
+
+### Upgrade notes
+
+- `AggregateMetricsCron` gained a `Magento\Framework\App\CacheInterface` constructor argument and is injected as a proxy in `src/etc/di.xml`, so run `bin/magento setup:di:compile` after updating.
+- The throttle marker is stored in the Magento cache without tags. `bin/magento cache:clean` does not clear it; `bin/magento cache:flush` does. To force a throttled metric to recompute immediately, use `bin/magento run_as_root:metric:collect --only=<metric_code>`, which ignores the throttle by design.
 
 ## [4.2.2] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `OrderAmountAggregator`, `OrderItemAmountAggregator`, `OrderItemCountAggregator`: these still run an unbounded full-table scan on every cron tick even after the N+1 fix in 4.2.1, and were the largest contributors to the DB load reported in #69. They now implement a new `IntervalAwareMetricAggregatorInterface` so `AggregateMetricsCron` throttles them to once every 5 minutes instead of every minute, while every other (cheap) aggregator keeps its existing per-minute schedule.
+- `AggregateMetricsCron`: a cache-backend exception while checking/marking an interval-throttled aggregator's last run no longer aborts the rest of that cron tick's aggregator loop, and an aggregator whose `aggregate()` returns `false` (a soft failure) is no longer falsely marked as a successful run - it retries on the next tick instead of being suppressed for 5 minutes.
+
 ## [4.2.2] - 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Navigate to **Stores → Configuration → Prometheus → Metric Configuration**
 
 The module automatically registers a cron job that runs every minute to aggregate metrics. The job uses a dedicated cron group: `run_as_root_prometheus_metrics_aggregator`.
 
+The four order aggregators (`magento_orders_amount_total`, `magento_orders_count_total`, `magento_orders_items_amount_total`, `magento_orders_items_count_total`) each run a full scan of `sales_order` / `sales_order_item`, which is too expensive to repeat every minute on a large store. They are therefore throttled to once every 5 minutes. Their values stay constant between runs, which is correct for a gauge. All other aggregators still run on every cron tick.
+
+The throttle remembers the last successful run in the Magento cache without a cache tag, so `bin/magento cache:clean` leaves it in place and only `bin/magento cache:flush` clears it. To force one metric to recompute right away, use `bin/magento run_as_root:metric:collect --only=<metric_code>`, which ignores the throttle.
+
 ## 🎯 Prometheus Setup
 
 ### Basic Configuration

--- a/Test/Unit/Aggregator/Order/OrderAmountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Order/OrderAmountAggregatorTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RunAsRoot\PrometheusExporter\Aggregator\Order\OrderAmountAggregator;
 use RunAsRoot\PrometheusExporter\Api\Data\MetricInterface;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
 
@@ -77,6 +78,7 @@ final class OrderAmountAggregatorTest extends TestCase
 
     public function test_it_throttles_to_five_minutes(): void
     {
+        self::assertInstanceOf(IntervalAwareMetricAggregatorInterface::class, $this->subject);
         self::assertSame(300, $this->subject->getMinIntervalInSeconds());
     }
 

--- a/Test/Unit/Aggregator/Order/OrderAmountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Order/OrderAmountAggregatorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Order;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SearchResultsInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Order\OrderAmountAggregator;
+use RunAsRoot\PrometheusExporter\Api\Data\MetricInterface;
+use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
+
+final class OrderAmountAggregatorTest extends TestCase
+{
+    private const METRIC_CODE = 'magento_orders_amount_total';
+
+    private OrderAmountAggregator $subject;
+
+    /** @var MockObject|MetricRepository */
+    private $metricRepository;
+
+    /** @var MockObject|SearchCriteriaBuilder */
+    private $searchCriteriaBuilder;
+
+    /** @var MockObject|UpdateMetricServiceInterface */
+    private $updateMetricService;
+
+    /** @var MockObject|ResourceConnection */
+    private $resourceConnection;
+
+    protected function setUp(): void
+    {
+        $this->metricRepository = $this->createMock(MetricRepository::class);
+        $this->searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+        $this->updateMetricService = $this->createMock(UpdateMetricServiceInterface::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+
+        $this->subject = new OrderAmountAggregator(
+            $this->metricRepository,
+            $this->searchCriteriaBuilder,
+            $this->updateMetricService,
+            $this->resourceConnection
+        );
+    }
+
+    private function mockResetMetrics(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+
+        $this->searchCriteriaBuilder->method('addFilter')
+            ->with('code', self::METRIC_CODE)
+            ->willReturnSelf();
+        $this->searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $metric = $this->createMock(MetricInterface::class);
+        $metric->expects($this->once())->method('setValue')->with('0');
+
+        $searchResults = $this->createMock(SearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$metric]);
+
+        $this->metricRepository->method('getList')->with($searchCriteria)->willReturn($searchResults);
+        $this->metricRepository->expects($this->once())->method('save')->with($metric);
+    }
+
+    public function test_it_exposes_metric_metadata(): void
+    {
+        self::assertSame(self::METRIC_CODE, $this->subject->getCode());
+        self::assertSame('gauge', $this->subject->getType());
+        self::assertSame('Magento2 Order Amount by state', $this->subject->getHelp());
+    }
+
+    public function test_it_throttles_to_five_minutes(): void
+    {
+        self::assertSame(300, $this->subject->getMinIntervalInSeconds());
+    }
+
+    public function test_it_resets_and_updates_grand_total_by_state_and_store(): void
+    {
+        $this->mockResetMetrics();
+
+        $connection = $this->createMock(AdapterInterface::class);
+        $this->resourceConnection->method('getConnection')->willReturn($connection);
+        $connection->method('getTableName')->willReturnArgument(0);
+
+        $rows = [
+            ['GRAND_TOTAL' => '199.90', 'ORDER_STATE' => 'complete', 'STORE_CODE' => 'default'],
+            ['GRAND_TOTAL' => '50.00', 'ORDER_STATE' => 'processing', 'STORE_CODE' => 'eu'],
+        ];
+        $connection->expects($this->once())->method('fetchAll')->willReturn($rows);
+
+        $expected = [
+            [self::METRIC_CODE, '199.90', ['state' => 'complete', 'store_code' => 'default']],
+            [self::METRIC_CODE, '50.00', ['state' => 'processing', 'store_code' => 'eu']],
+        ];
+        $callCount = 0;
+        $this->updateMetricService->expects($this->exactly(count($rows)))
+            ->method('update')
+            ->willReturnCallback(function (...$args) use (&$callCount, $expected) {
+                self::assertEquals($expected[$callCount], $args);
+                $callCount++;
+
+                return true;
+            });
+
+        self::assertTrue($this->subject->aggregate());
+    }
+
+    public function test_it_returns_true_without_updating_when_there_are_no_orders(): void
+    {
+        $this->mockResetMetrics();
+
+        $connection = $this->createMock(AdapterInterface::class);
+        $this->resourceConnection->method('getConnection')->willReturn($connection);
+        $connection->method('getTableName')->willReturnArgument(0);
+        $connection->expects($this->once())->method('fetchAll')->willReturn([]);
+
+        $this->updateMetricService->expects($this->never())->method('update');
+
+        self::assertTrue($this->subject->aggregate());
+    }
+}

--- a/Test/Unit/Aggregator/Order/OrderCountAggregatorTest.php
+++ b/Test/Unit/Aggregator/Order/OrderCountAggregatorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Order;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SearchResultsInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Order\OrderCountAggregator;
+use RunAsRoot\PrometheusExporter\Api\Data\MetricInterface;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+final class OrderCountAggregatorTest extends TestCase
+{
+    private const METRIC_CODE = 'magento_orders_count_total';
+
+    private OrderCountAggregator $subject;
+
+    /** @var MockObject|MetricRepository */
+    private $metricRepository;
+
+    /** @var MockObject|SearchCriteriaBuilder */
+    private $searchCriteriaBuilder;
+
+    /** @var MockObject|UpdateMetricService */
+    private $updateMetricService;
+
+    /** @var MockObject|ResourceConnection */
+    private $resourceConnection;
+
+    protected function setUp(): void
+    {
+        $this->metricRepository = $this->createMock(MetricRepository::class);
+        $this->searchCriteriaBuilder = $this->createMock(SearchCriteriaBuilder::class);
+        $this->updateMetricService = $this->createMock(UpdateMetricService::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+
+        $this->subject = new OrderCountAggregator(
+            $this->metricRepository,
+            $this->searchCriteriaBuilder,
+            $this->updateMetricService,
+            $this->resourceConnection
+        );
+    }
+
+    private function mockResetMetrics(): void
+    {
+        $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
+
+        $this->searchCriteriaBuilder->method('addFilter')
+            ->with('code', self::METRIC_CODE)
+            ->willReturnSelf();
+        $this->searchCriteriaBuilder->method('create')->willReturn($searchCriteria);
+
+        $metric = $this->createMock(MetricInterface::class);
+        $metric->expects($this->once())->method('setValue')->with('0');
+
+        $searchResults = $this->createMock(SearchResultsInterface::class);
+        $searchResults->method('getItems')->willReturn([$metric]);
+
+        $this->metricRepository->method('getList')->with($searchCriteria)->willReturn($searchResults);
+        $this->metricRepository->expects($this->once())->method('save')->with($metric);
+    }
+
+    public function test_it_exposes_metric_metadata(): void
+    {
+        self::assertSame(self::METRIC_CODE, $this->subject->getCode());
+        self::assertSame('gauge', $this->subject->getType());
+        self::assertSame('Magento2 Order Count by state', $this->subject->getHelp());
+    }
+
+    public function test_it_throttles_to_five_minutes(): void
+    {
+        self::assertInstanceOf(IntervalAwareMetricAggregatorInterface::class, $this->subject);
+        self::assertSame(300, $this->subject->getMinIntervalInSeconds());
+    }
+
+    public function test_it_resets_and_updates_order_count_by_state_and_store(): void
+    {
+        $this->mockResetMetrics();
+
+        $connection = $this->createMock(AdapterInterface::class);
+        $this->resourceConnection->method('getConnection')->willReturn($connection);
+        $connection->method('getTableName')->willReturnArgument(0);
+
+        $rows = [
+            ['ORDER_COUNT' => '12', 'ORDER_STATE' => 'complete', 'STORE_CODE' => 'default'],
+            ['ORDER_COUNT' => '3', 'ORDER_STATE' => 'processing', 'STORE_CODE' => 'eu'],
+        ];
+        $connection->expects($this->once())->method('fetchAll')->willReturn($rows);
+
+        $expected = [
+            [self::METRIC_CODE, '12', ['state' => 'complete', 'store_code' => 'default']],
+            [self::METRIC_CODE, '3', ['state' => 'processing', 'store_code' => 'eu']],
+        ];
+        $callCount = 0;
+        $this->updateMetricService->expects($this->exactly(count($rows)))
+            ->method('update')
+            ->willReturnCallback(function (...$args) use (&$callCount, $expected) {
+                self::assertEquals($expected[$callCount], $args);
+                $callCount++;
+
+                return true;
+            });
+
+        self::assertTrue($this->subject->aggregate());
+    }
+
+    public function test_it_returns_true_without_updating_when_there_are_no_orders(): void
+    {
+        $this->mockResetMetrics();
+
+        $connection = $this->createMock(AdapterInterface::class);
+        $this->resourceConnection->method('getConnection')->willReturn($connection);
+        $connection->method('getTableName')->willReturnArgument(0);
+        $connection->expects($this->once())->method('fetchAll')->willReturn([]);
+
+        $this->updateMetricService->expects($this->never())->method('update');
+
+        self::assertTrue($this->subject->aggregate());
+    }
+}

--- a/Test/Unit/Aggregator/Order/OrderItemThrottleTest.php
+++ b/Test/Unit/Aggregator/Order/OrderItemThrottleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Aggregator\Order;
+
+use Magento\Framework\App\ResourceConnection;
+use PHPUnit\Framework\TestCase;
+use RunAsRoot\PrometheusExporter\Aggregator\Order\OrderItemAmountAggregator;
+use RunAsRoot\PrometheusExporter\Aggregator\Order\OrderItemCountAggregator;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
+
+/**
+ * OrderItemAmountAggregator/OrderItemCountAggregator run a single streamed query, but it is
+ * still an unbounded full scan over sales_order_item - this pins the throttle contract added on
+ * top of the N+1 fix in #66/#69, since the query-shape/derivation behavior is already covered by
+ * OrderItemAggregatorStatusDerivationTest.
+ */
+final class OrderItemThrottleTest extends TestCase
+{
+    public function test_order_item_amount_aggregator_is_interval_aware_and_throttles_to_five_minutes(): void
+    {
+        $sut = new OrderItemAmountAggregator(
+            $this->createMock(UpdateMetricService::class),
+            $this->createMock(ResourceConnection::class)
+        );
+
+        self::assertInstanceOf(IntervalAwareMetricAggregatorInterface::class, $sut);
+        self::assertSame(300, $sut->getMinIntervalInSeconds());
+    }
+
+    public function test_order_item_count_aggregator_is_interval_aware_and_throttles_to_five_minutes(): void
+    {
+        $sut = new OrderItemCountAggregator(
+            $this->createMock(UpdateMetricService::class),
+            $this->createMock(ResourceConnection::class)
+        );
+
+        self::assertInstanceOf(IntervalAwareMetricAggregatorInterface::class, $sut);
+        self::assertSame(300, $sut->getMinIntervalInSeconds());
+    }
+}

--- a/Test/Unit/Cron/AggregateMetricsCronUnitTest.php
+++ b/Test/Unit/Cron/AggregateMetricsCronUnitTest.php
@@ -8,7 +8,6 @@ use Magento\Framework\App\CacheInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricRepositoryInterface;
 use RunAsRoot\PrometheusExporter\Cron\AggregateMetricsCron;
@@ -39,7 +38,13 @@ final class AggregateMetricsCronUnitTest extends TestCase
         /** @var LoggerInterface | MockObject $loggerMock */
         $loggerMock = $this->createMock(LoggerInterface::class);
 
-        return new AggregateMetricsCron($metricAggregatorPool, $configMock, $metricRepositoryMock, $loggerMock, $this->cache);
+        return new AggregateMetricsCron(
+            $metricAggregatorPool,
+            $configMock,
+            $metricRepositoryMock,
+            $loggerMock,
+            $this->cache
+        );
     }
 
     public function testItShouldUpdateExistingMetric(): void
@@ -66,13 +71,14 @@ final class AggregateMetricsCronUnitTest extends TestCase
 
     public function test_it_skips_an_interval_aware_aggregator_that_ran_too_recently(): void
     {
-        $aggregator = $this->createMockForIntersectionOfInterfaces([
-            MetricAggregatorInterface::class,
-            IntervalAwareMetricAggregatorInterface::class,
-        ]);
+        $aggregator = $this->createMock(ThrottledMetricAggregatorInterface::class);
         $aggregator->method('getCode')->willReturn('magento_orders_amount_total');
         $aggregator->method('getMinIntervalInSeconds')->willReturn(300);
         $aggregator->expects($this->never())->method('aggregate');
+
+        $unrelated = $this->createMock(MetricAggregatorInterface::class);
+        $unrelated->method('getCode')->willReturn('magento_cms_page_count_total');
+        $unrelated->expects($this->once())->method('aggregate')->willReturn(true);
 
         $this->cache->expects($this->once())
             ->method('load')
@@ -80,17 +86,17 @@ final class AggregateMetricsCronUnitTest extends TestCase
             ->willReturn('1');
         $this->cache->expects($this->never())->method('save');
 
-        $sut = $this->makeSut([$aggregator], ['magento_orders_amount_total']);
+        $sut = $this->makeSut([$aggregator, $unrelated], [
+            'magento_orders_amount_total',
+            'magento_cms_page_count_total',
+        ]);
 
         $sut->execute();
     }
 
     public function test_it_runs_and_marks_an_interval_aware_aggregator_that_is_due(): void
     {
-        $aggregator = $this->createMockForIntersectionOfInterfaces([
-            MetricAggregatorInterface::class,
-            IntervalAwareMetricAggregatorInterface::class,
-        ]);
+        $aggregator = $this->createMock(ThrottledMetricAggregatorInterface::class);
         $aggregator->method('getCode')->willReturn('magento_orders_amount_total');
         $aggregator->method('getMinIntervalInSeconds')->willReturn(300);
         $aggregator->expects($this->once())->method('aggregate')->willReturn(true);
@@ -110,10 +116,7 @@ final class AggregateMetricsCronUnitTest extends TestCase
 
     public function test_it_does_not_mark_an_interval_aware_aggregator_that_soft_fails(): void
     {
-        $aggregator = $this->createMockForIntersectionOfInterfaces([
-            MetricAggregatorInterface::class,
-            IntervalAwareMetricAggregatorInterface::class,
-        ]);
+        $aggregator = $this->createMock(ThrottledMetricAggregatorInterface::class);
         $aggregator->method('getCode')->willReturn('magento_orders_amount_total');
         $aggregator->method('getMinIntervalInSeconds')->willReturn(300);
         $aggregator->expects($this->once())->method('aggregate')->willReturn(false);
@@ -128,10 +131,7 @@ final class AggregateMetricsCronUnitTest extends TestCase
 
     public function test_a_cache_exception_on_one_aggregator_does_not_abort_the_rest_of_the_loop(): void
     {
-        $throttled = $this->createMockForIntersectionOfInterfaces([
-            MetricAggregatorInterface::class,
-            IntervalAwareMetricAggregatorInterface::class,
-        ]);
+        $throttled = $this->createMock(ThrottledMetricAggregatorInterface::class);
         $throttled->method('getCode')->willReturn('magento_orders_amount_total');
         $throttled->method('getMinIntervalInSeconds')->willReturn(300);
         $throttled->expects($this->never())->method('aggregate');
@@ -150,5 +150,20 @@ final class AggregateMetricsCronUnitTest extends TestCase
         ]);
 
         $sut->execute();
+    }
+
+    public function test_execute_only_ignores_the_throttle_so_the_cli_can_always_force_a_run(): void
+    {
+        $aggregator = $this->createMock(ThrottledMetricAggregatorInterface::class);
+        $aggregator->method('getCode')->willReturn('magento_orders_amount_total');
+        $aggregator->method('getMinIntervalInSeconds')->willReturn(300);
+        $aggregator->expects($this->once())->method('aggregate')->willReturn(true);
+
+        $this->cache->expects($this->never())->method('load');
+        $this->cache->expects($this->never())->method('save');
+
+        $sut = $this->makeSut([$aggregator], ['magento_orders_amount_total']);
+
+        $sut->executeOnly('magento_orders_amount_total');
     }
 }

--- a/Test/Unit/Cron/AggregateMetricsCronUnitTest.php
+++ b/Test/Unit/Cron/AggregateMetricsCronUnitTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace RunAsRoot\PrometheusExporter\Test\Unit\Cron;
 
+use Magento\Framework\App\CacheInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricRepositoryInterface;
 use RunAsRoot\PrometheusExporter\Cron\AggregateMetricsCron;
@@ -15,6 +17,31 @@ use RunAsRoot\PrometheusExporter\Metric\MetricAggregatorPool;
 
 final class AggregateMetricsCronUnitTest extends TestCase
 {
+    /** @var MockObject|CacheInterface */
+    private $cache;
+
+    protected function setUp(): void
+    {
+        $this->cache = $this->createMock(CacheInterface::class);
+    }
+
+    private function makeSut(array $items, array $enabledMetrics): AggregateMetricsCron
+    {
+        $metricAggregatorPool = new MetricAggregatorPool($items);
+
+        /** @var Config | MockObject $configMock */
+        $configMock = $this->createMock(Config::class);
+        $configMock->method('getMetricsStatus')->willReturn($enabledMetrics);
+
+        /** @var MetricRepositoryInterface | MockObject $metricRepositoryMock */
+        $metricRepositoryMock = $this->createMock(MetricRepositoryInterface::class);
+
+        /** @var LoggerInterface | MockObject $loggerMock */
+        $loggerMock = $this->createMock(LoggerInterface::class);
+
+        return new AggregateMetricsCron($metricAggregatorPool, $configMock, $metricRepositoryMock, $loggerMock, $this->cache);
+    }
+
     public function testItShouldUpdateExistingMetric(): void
     {
         $aggregator = $this->createMock(MetricAggregatorInterface::class);
@@ -24,26 +51,103 @@ final class AggregateMetricsCronUnitTest extends TestCase
         $aggregatorTwo = $this->createMock(MetricAggregatorInterface::class);
         $aggregatorTwo->expects($this->once())->method('getCode')->willReturn('magento2_orders_count_other');
 
-        /** @var Config | MockObject $configMock */
-        $configMock = $this->createMock(Config::class);
-        $configMock->expects($this->once())->method('getMetricsStatus')->willReturn([
+        $this->cache->expects($this->never())->method('load');
+        $this->cache->expects($this->never())->method('save');
+
+        $sut = $this->makeSut([$aggregator, $aggregatorTwo], [
             'magento2_orders_count_total',
             'magento2_orders_items_amount_total',
             'magento2_orders_items_count_total',
             'magento_cms_page_count_total',
         ]);
 
-        $items = [ $aggregator, $aggregatorTwo ];
+        $sut->execute();
+    }
 
-        $metricAggregatorPool = new MetricAggregatorPool($items);
+    public function test_it_skips_an_interval_aware_aggregator_that_ran_too_recently(): void
+    {
+        $aggregator = $this->createMockForIntersectionOfInterfaces([
+            MetricAggregatorInterface::class,
+            IntervalAwareMetricAggregatorInterface::class,
+        ]);
+        $aggregator->method('getCode')->willReturn('magento_orders_amount_total');
+        $aggregator->method('getMinIntervalInSeconds')->willReturn(300);
+        $aggregator->expects($this->never())->method('aggregate');
 
-        /** @var MetricRepositoryInterface | MockObject $metricRepositoryMock */
-        $metricRepositoryMock = $this->createMock(MetricRepositoryInterface::class);
+        $this->cache->expects($this->once())
+            ->method('load')
+            ->with('run_as_root_prometheus_last_aggregated_magento_orders_amount_total')
+            ->willReturn('1');
+        $this->cache->expects($this->never())->method('save');
 
-        /** @var LoggerInterface | MockObject $loggerMock */
-        $loggerMock = $this->createMock(LoggerInterface::class);
+        $sut = $this->makeSut([$aggregator], ['magento_orders_amount_total']);
 
-        $sut = new AggregateMetricsCron($metricAggregatorPool, $configMock, $metricRepositoryMock, $loggerMock);
+        $sut->execute();
+    }
+
+    public function test_it_runs_and_marks_an_interval_aware_aggregator_that_is_due(): void
+    {
+        $aggregator = $this->createMockForIntersectionOfInterfaces([
+            MetricAggregatorInterface::class,
+            IntervalAwareMetricAggregatorInterface::class,
+        ]);
+        $aggregator->method('getCode')->willReturn('magento_orders_amount_total');
+        $aggregator->method('getMinIntervalInSeconds')->willReturn(300);
+        $aggregator->expects($this->once())->method('aggregate')->willReturn(true);
+
+        $this->cache->expects($this->once())
+            ->method('load')
+            ->with('run_as_root_prometheus_last_aggregated_magento_orders_amount_total')
+            ->willReturn(false);
+        $this->cache->expects($this->once())
+            ->method('save')
+            ->with('1', 'run_as_root_prometheus_last_aggregated_magento_orders_amount_total', [], 300);
+
+        $sut = $this->makeSut([$aggregator], ['magento_orders_amount_total']);
+
+        $sut->execute();
+    }
+
+    public function test_it_does_not_mark_an_interval_aware_aggregator_that_soft_fails(): void
+    {
+        $aggregator = $this->createMockForIntersectionOfInterfaces([
+            MetricAggregatorInterface::class,
+            IntervalAwareMetricAggregatorInterface::class,
+        ]);
+        $aggregator->method('getCode')->willReturn('magento_orders_amount_total');
+        $aggregator->method('getMinIntervalInSeconds')->willReturn(300);
+        $aggregator->expects($this->once())->method('aggregate')->willReturn(false);
+
+        $this->cache->method('load')->willReturn(false);
+        $this->cache->expects($this->never())->method('save');
+
+        $sut = $this->makeSut([$aggregator], ['magento_orders_amount_total']);
+
+        $sut->execute();
+    }
+
+    public function test_a_cache_exception_on_one_aggregator_does_not_abort_the_rest_of_the_loop(): void
+    {
+        $throttled = $this->createMockForIntersectionOfInterfaces([
+            MetricAggregatorInterface::class,
+            IntervalAwareMetricAggregatorInterface::class,
+        ]);
+        $throttled->method('getCode')->willReturn('magento_orders_amount_total');
+        $throttled->method('getMinIntervalInSeconds')->willReturn(300);
+        $throttled->expects($this->never())->method('aggregate');
+
+        $unrelated = $this->createMock(MetricAggregatorInterface::class);
+        $unrelated->method('getCode')->willReturn('magento_cms_page_count_total');
+        $unrelated->expects($this->once())->method('aggregate')->willReturn(true);
+
+        $this->cache->method('load')
+            ->with('run_as_root_prometheus_last_aggregated_magento_orders_amount_total')
+            ->willThrowException(new \RuntimeException('cache backend unavailable'));
+
+        $sut = $this->makeSut([$throttled, $unrelated], [
+            'magento_orders_amount_total',
+            'magento_cms_page_count_total',
+        ]);
 
         $sut->execute();
     }

--- a/Test/Unit/Cron/ThrottledMetricAggregatorInterface.php
+++ b/Test/Unit/Cron/ThrottledMetricAggregatorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Test\Unit\Cron;
+
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
+
+/**
+ * Test double for an aggregator that opts into interval throttling.
+ *
+ * PHPUnit's createMockForIntersectionOfInterfaces() would express this inline, but it only exists
+ * from PHPUnit 10 onwards and this module still supports PHPUnit 9.5 (Magento 2.4.6 / 2.4.7).
+ */
+interface ThrottledMetricAggregatorInterface extends
+    MetricAggregatorInterface,
+    IntervalAwareMetricAggregatorInterface
+{
+}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "run_as_root/magento2-prometheus-exporter",
   "description": "Magento2 Prometheus Exporter",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "type": "magento2-module",
   "license": "MIT",
   "homepage": "https://github.com/run-as-root/magento2-prometheus-exporter",

--- a/src/Aggregator/Order/OrderAmountAggregator.php
+++ b/src/Aggregator/Order/OrderAmountAggregator.php
@@ -8,14 +8,24 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\NoSuchEntityException;
 use RunAsRoot\PrometheusExporter\Api\Data\MetricInterface;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricServiceInterface;
 use function array_key_exists;
 
-class OrderAmountAggregator implements MetricAggregatorInterface
+class OrderAmountAggregator implements MetricAggregatorInterface, IntervalAwareMetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_amount_total';
+
+    /**
+     * This aggregator runs a full, unbounded GROUP BY scan over the entire sales_order table
+     * (no WHERE/LIMIT). On large stores that is too expensive to run on every one-minute cron
+     * tick, so it is throttled independently of the shared cron schedule.
+     *
+     * @see https://github.com/run-as-root/magento2-prometheus-exporter/issues/69
+     */
+    private const MIN_INTERVAL_IN_SECONDS = 300;
 
     private MetricRepository $metricRepository;
     private SearchCriteriaBuilder $searchCriteriaBuilder;
@@ -47,6 +57,11 @@ class OrderAmountAggregator implements MetricAggregatorInterface
     public function getType(): string
     {
         return 'gauge';
+    }
+
+    public function getMinIntervalInSeconds(): int
+    {
+        return self::MIN_INTERVAL_IN_SECONDS;
     }
 
     public function aggregate(): bool

--- a/src/Aggregator/Order/OrderCountAggregator.php
+++ b/src/Aggregator/Order/OrderCountAggregator.php
@@ -8,14 +8,24 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\NoSuchEntityException;
 use RunAsRoot\PrometheusExporter\Api\Data\MetricInterface;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 use function array_key_exists;
 
-class OrderCountAggregator implements MetricAggregatorInterface
+class OrderCountAggregator implements MetricAggregatorInterface, IntervalAwareMetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_count_total';
+
+    /**
+     * This aggregator runs a full, unbounded GROUP BY scan over the entire sales_order table
+     * (no WHERE/LIMIT). On large stores that is too expensive to run on every one-minute cron
+     * tick, so it is throttled independently of the shared cron schedule.
+     *
+     * @see https://github.com/run-as-root/magento2-prometheus-exporter/issues/69
+     */
+    private const MIN_INTERVAL_IN_SECONDS = 300;
 
     private MetricRepository $metricRepository;
     private SearchCriteriaBuilder $searchCriteriaBuilder;
@@ -47,6 +57,11 @@ class OrderCountAggregator implements MetricAggregatorInterface
     public function getType(): string
     {
         return 'gauge';
+    }
+
+    public function getMinIntervalInSeconds(): int
+    {
+        return self::MIN_INTERVAL_IN_SECONDS;
     }
 
     public function aggregate(): bool

--- a/src/Aggregator/Order/OrderItemAmountAggregator.php
+++ b/src/Aggregator/Order/OrderItemAmountAggregator.php
@@ -6,12 +6,21 @@ namespace RunAsRoot\PrometheusExporter\Aggregator\Order;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Model\Order\Item;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 
-class OrderItemAmountAggregator implements MetricAggregatorInterface
+class OrderItemAmountAggregator implements MetricAggregatorInterface, IntervalAwareMetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_items_amount_total';
+
+    /**
+     * This is a single streamed query, but still an unbounded full scan over sales_order_item,
+     * so it is throttled independently of the shared cron schedule.
+     *
+     * @see https://github.com/run-as-root/magento2-prometheus-exporter/issues/69
+     */
+    private const MIN_INTERVAL_IN_SECONDS = 300;
 
     private UpdateMetricService $updateMetricService;
     private ResourceConnection $resourceConnection;
@@ -37,6 +46,11 @@ class OrderItemAmountAggregator implements MetricAggregatorInterface
     public function getType(): string
     {
         return 'gauge';
+    }
+
+    public function getMinIntervalInSeconds(): int
+    {
+        return self::MIN_INTERVAL_IN_SECONDS;
     }
 
     public function aggregate(): bool

--- a/src/Aggregator/Order/OrderItemCountAggregator.php
+++ b/src/Aggregator/Order/OrderItemCountAggregator.php
@@ -6,12 +6,21 @@ namespace RunAsRoot\PrometheusExporter\Aggregator\Order;
 
 use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Model\Order\Item;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Service\UpdateMetricService;
 
-class OrderItemCountAggregator implements MetricAggregatorInterface
+class OrderItemCountAggregator implements MetricAggregatorInterface, IntervalAwareMetricAggregatorInterface
 {
     private const METRIC_CODE = 'magento_orders_items_count_total';
+
+    /**
+     * This is a single streamed query, but still an unbounded full scan over sales_order_item,
+     * so it is throttled independently of the shared cron schedule.
+     *
+     * @see https://github.com/run-as-root/magento2-prometheus-exporter/issues/69
+     */
+    private const MIN_INTERVAL_IN_SECONDS = 300;
 
     private UpdateMetricService $updateMetricService;
     private ResourceConnection $resourceConnection;
@@ -37,6 +46,11 @@ class OrderItemCountAggregator implements MetricAggregatorInterface
     public function getType(): string
     {
         return 'gauge';
+    }
+
+    public function getMinIntervalInSeconds(): int
+    {
+        return self::MIN_INTERVAL_IN_SECONDS;
     }
 
     public function aggregate(): bool

--- a/src/Api/IntervalAwareMetricAggregatorInterface.php
+++ b/src/Api/IntervalAwareMetricAggregatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RunAsRoot\PrometheusExporter\Api;
+
+interface IntervalAwareMetricAggregatorInterface
+{
+    /**
+     * Aggregators computing expensive queries (e.g. full table scans) can implement this
+     * to be skipped by AggregateMetricsCron until at least this many seconds have passed
+     * since their last successful run, instead of running on every cron tick.
+     *
+     * @return int
+     */
+    public function getMinIntervalInSeconds(): int;
+}

--- a/src/Cron/AggregateMetricsCron.php
+++ b/src/Cron/AggregateMetricsCron.php
@@ -4,32 +4,41 @@ declare(strict_types=1);
 
 namespace RunAsRoot\PrometheusExporter\Cron;
 
+use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Psr\Log\LoggerInterface;
+use RunAsRoot\PrometheusExporter\Api\IntervalAwareMetricAggregatorInterface;
+use RunAsRoot\PrometheusExporter\Api\MetricAggregatorInterface;
 use RunAsRoot\PrometheusExporter\Api\MetricRepositoryInterface;
-use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
-use function in_array;
 use RunAsRoot\PrometheusExporter\Data\Config;
 use RunAsRoot\PrometheusExporter\Metric\MetricAggregatorPool;
+use RunAsRoot\PrometheusExporter\Repository\MetricRepository;
+use function in_array;
 use function json_decode;
 
 class AggregateMetricsCron
 {
+    private const CACHE_KEY_PREFIX = 'run_as_root_prometheus_last_aggregated_';
+    private const CACHE_VALUE_ALREADY_RUN = '1';
+
     private MetricAggregatorPool $metricAggregatorPool;
     private Config $config;
     private MetricRepositoryInterface $metricRepository;
     private LoggerInterface $logger;
+    private CacheInterface $cache;
 
     public function __construct(
         MetricAggregatorPool $metricAggregatorPool,
         Config $config,
         MetricRepositoryInterface $metricRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        CacheInterface $cache
     ) {
         $this->metricAggregatorPool = $metricAggregatorPool;
         $this->config = $config;
         $this->metricRepository = $metricRepository;
         $this->logger = $logger;
+        $this->cache = $cache;
     }
 
     public function execute(): void
@@ -42,7 +51,13 @@ class AggregateMetricsCron
             }
 
             try {
-                $metricAggregator->aggregate();
+                if (!$this->isDue($metricAggregator)) {
+                    continue;
+                }
+
+                if ($metricAggregator->aggregate()) {
+                    $this->markAggregated($metricAggregator);
+                }
             } catch (\Exception $e) {
                 $msg = sprintf('AggregateMetricsCron: Unable to process jobCode:%s ', $metricAggregator->getCode());
                 $this->logger->error($msg . $e->getMessage());
@@ -69,5 +84,33 @@ class AggregateMetricsCron
         }
 
         return $result;
+    }
+
+    private function isDue(MetricAggregatorInterface $metricAggregator): bool
+    {
+        if (!$metricAggregator instanceof IntervalAwareMetricAggregatorInterface) {
+            return true;
+        }
+
+        return !$this->cache->load($this->getCacheKey($metricAggregator));
+    }
+
+    private function markAggregated(MetricAggregatorInterface $metricAggregator): void
+    {
+        if (!$metricAggregator instanceof IntervalAwareMetricAggregatorInterface) {
+            return;
+        }
+
+        $this->cache->save(
+            self::CACHE_VALUE_ALREADY_RUN,
+            $this->getCacheKey($metricAggregator),
+            [],
+            $metricAggregator->getMinIntervalInSeconds()
+        );
+    }
+
+    private function getCacheKey(MetricAggregatorInterface $metricAggregator): string
+    {
+        return self::CACHE_KEY_PREFIX . $metricAggregator->getCode();
     }
 }


### PR DESCRIPTION
## Summary

Fixes the remainder of #69. This branch originally also rewrote the N+1 bug in `OrderItemAmountAggregator`/`OrderItemCountAggregator`, but `master` picked up an independent, more complete fix for that in the meantime (#66, released as 4.2.1 - correctly handles children-inherited backorder status, which this branch's first attempt did not). After rebasing, this PR only carries what's still missing from #69 on top of that:

- `OrderAmountAggregator` itself was never touched by #66 - it still runs an unbounded `GROUP BY` scan over the entire `sales_order` table on every one-minute cron tick. Per the issue's own data (8083 executions, up to 12s peak, ~3.07B rows examined cumulatively), this was one of the two largest contributors to the reported production 502s.
- All three full-table-scan order aggregators (`OrderAmountAggregator`, `OrderItemAmountAggregator`, `OrderItemCountAggregator`) now implement a new `IntervalAwareMetricAggregatorInterface`, so `AggregateMetricsCron` throttles them to once every 5 minutes instead of every cron tick - per the issue's own suggestion that per-minute freshness isn't needed for gauges like these - while every other (cheap) aggregator keeps its existing per-minute schedule.
- `AggregateMetricsCron`: a cache-backend exception while checking/marking an interval-throttled aggregator's last run no longer aborts the rest of that cron tick's aggregator loop, and an aggregator whose `aggregate()` returns `false` (a soft failure) is no longer falsely marked as a successful run - it retries on the next tick instead of being suppressed for 5 minutes.

Left out of scope (considered, not touched here): a pre-existing unrelated bug where `OrderAmountAggregator`/`OrderCountAggregator` compute prefixed table names but the query string still hardcodes literal `sales_order`/`store`.

## Test plan
- [x] Added unit tests for `OrderAmountAggregator` (no coverage existed before) and a small throttle-contract test for the two item aggregators (status-derivation behavior is already covered by `OrderItemAggregatorStatusDerivationTest` from #66)
- [x] Updated `AggregateMetricsCronUnitTest` for the new `CacheInterface` dependency, throttle skip/run behavior, soft-failure handling, and cache-exception isolation
- [x] `vendor/bin/phpunit Test/Unit` - no new failures introduced vs `origin/master` baseline (pre-existing errors are missing generated Magento classes not installable from this repo standalone)
- [x] `phpstan analyse` - no new errors vs `origin/master` baseline
- [x] Reviewed via a multi-agent pass (performance, Magento best-practices, security) before opening this PR - caught and fixed a critical bug in this branch's original SQL rewrite (grouping by a non-existent `sales_order_item.status` column) before it ever shipped, plus a cache-exception isolation bug and a soft-failure throttle bug